### PR TITLE
Implement lagda_md.postprocess and slimmed Lua filters

### DIFF
--- a/lagda_md/__init__.py
+++ b/lagda_md/__init__.py
@@ -40,5 +40,6 @@ contain `@@` safely.
 
 from .macros import MacroEntry, MacroTable
 from .preprocess import preprocess
+from .postprocess import postprocess, build_label_map
 
-__all__ = ["MacroEntry", "MacroTable", "preprocess"]
+__all__ = ["MacroEntry", "MacroTable", "preprocess", "postprocess", "build_label_map"]

--- a/lagda_md/filters/agda-filter.lua
+++ b/lagda_md/filters/agda-filter.lua
@@ -17,10 +17,25 @@
 --  @return table mapping keys to values.
 local function parse_agda_term_payload(text)
   local args = {}
-  for key, value in string.gmatch(text, "([^=@]+)=([^@]+)") do
-    key = key:match("^%s*(.-)%s*$")
-    value = value:match("^%s*(.-)%s*$")
-    args[key] = value
+  -- Split on @@ field separator.  Preserves single @ characters
+  -- (which arise from the @@ → @ @ escape applied by preprocess).
+  local position = 1
+  while position <= #text do
+    local separator_start, separator_end = text:find("@@", position, true)
+    local field
+    if separator_start then
+      field = text:sub(position, separator_start - 1)
+      position = separator_end + 1
+    else
+      field = text:sub(position)
+      position = #text + 1
+    end
+    local key, value = field:match("^([^=]+)=(.*)$")
+    if key then
+      key = key:match("^%s*(.-)%s*$")
+      value = value:match("^%s*(.-)%s*$")
+      args[key] = value
+    end
   end
   return args
 end

--- a/lagda_md/filters/agda-filter.lua
+++ b/lagda_md/filters/agda-filter.lua
@@ -1,0 +1,74 @@
+-- agda-filter.lua
+-- Pandoc Lua filter for the agda-lagda-migrator package.
+--
+-- This is the slimmed default filter, handling only the universal case:
+-- @@AgdaTerm@@ markers emitted by lagda_md.preprocess for Agda identifiers
+-- in prose are converted into Code elements with the appropriate CSS class.
+--
+-- Projects whose .lagda sources use \label, \Cref, or \caption can layer
+-- the optional `cross-refs.lua` filter on top of this one to handle those
+-- constructs.
+--
+-- The full FLS-shaped filter (with HighlightPlaceholder and other
+-- FLS-specific handlers) lives at examples/fls-pipeline/agda-filter.lua.
+
+--- Parses key=value pairs from an AgdaTerm marker payload.
+--  Example input: "basename=Acnt@@class=AgdaRecord"
+--  @return table mapping keys to values.
+local function parse_agda_term_payload(text)
+  local args = {}
+  for key, value in string.gmatch(text, "([^=@]+)=([^@]+)") do
+    key = key:match("^%s*(.-)%s*$")
+    value = value:match("^%s*(.-)%s*$")
+    args[key] = value
+  end
+  return args
+end
+
+--- Constructs a Pandoc attribute structure compatible with both 2.x and 3.x.
+local function make_attrs(classes)
+  classes = classes or {}
+  local identifier = ""
+  local kv = {}
+  if type(pandoc.Attr) == "function" then
+    return pandoc.Attr(identifier, classes, kv)
+  else
+    return {identifier, classes, kv}
+  end
+end
+
+--- Reverses the @@ -> @ @ escape applied by lagda_md.preprocess.
+local function unescape(text)
+  return (text:gsub("@ @", "@@"))
+end
+
+--- Processes Code inline elements containing AgdaTerm markers.
+--  Input shape: <code>@@AgdaTerm@@basename=NAME@@class=CLASS@@</code>.
+--  Output: a Code element with text=NAME and CSS class=CLASS.
+function Code(inline)
+  local payload = inline.text:match("^%s*@@AgdaTerm@@(.-)@@%s*$")
+  if not payload then
+    return inline
+  end
+
+  local args = parse_agda_term_payload(payload)
+  if args.basename and args["class"] then
+    return pandoc.Code(unescape(args.basename), make_attrs({args["class"]}))
+  end
+
+  io.stderr:write("Warning: malformed AgdaTerm payload: " .. payload .. "\n")
+  return inline
+end
+
+--- Walks Div elements to ensure inline handlers fire on inner content,
+--  and adds markdown="1" to theorem-class divs (a Pandoc convention that
+--  lets the Markdown writer process Markdown content nested inside HTML).
+function Div(div)
+  for _, class in ipairs(div.classes) do
+    if class == "theorem" then
+      div.attributes["markdown"] = "1"
+      break
+    end
+  end
+  return pandoc.walk_block(div, { Code = Code })
+end

--- a/lagda_md/filters/cross-refs.lua
+++ b/lagda_md/filters/cross-refs.lua
@@ -1,0 +1,86 @@
+-- cross-refs.lua
+-- Optional Pandoc Lua filter for projects whose .lagda sources use
+-- \label, \Cref / \cref, and \caption.  Layered on top of agda-filter.lua
+-- when the user passes --enable-cross-refs to convert_lagda.py.
+--
+-- Transforms:
+--   \label{target}       -> <a id="sanitized_target"></a>
+--   \Cref{a,b,...}       -> Markdown links with prefix ("Figure", "Section", etc.)
+--   \cref{a,b,...}       -> identical, lowercase form
+--   \caption{text}       -> Span with class "caption-text" and bold "Caption:" prefix
+
+local function sanitize(target)
+  return target:gsub("[^%w%-_%.%:]", "_")
+end
+
+local function make_attrs(classes)
+  classes = classes or {}
+  if type(pandoc.Attr) == "function" then
+    return pandoc.Attr("", classes, {})
+  else
+    return {"", classes, {}}
+  end
+end
+
+local function infer_prefix(target)
+  if     target:match("^fig:") then return "Figure"
+  elseif target:match("^sec:") then return "Section"
+  elseif target:match("^tbl:") then return "Table"
+  elseif target:match("^eq:")  then return "Equation"
+  else                              return "Ref."
+  end
+end
+
+local function transform_latex_command(text)
+  -- \label{target}
+  local label_target = text:match("^\\label%s*{(.-)}$")
+  if label_target then
+    return pandoc.RawInline("html", '<a id="' .. sanitize(label_target) .. '"></a>')
+  end
+
+  -- \Cref{a,b,...} or \cref{a,b,...}
+  local cref_targets = text:match("^\\[Cc]ref%s*{(.-)}$")
+  if cref_targets then
+    local inlines = {}
+    local first = true
+    for target in cref_targets:gmatch("([^,]+)") do
+      target = target:match("^%s*(.-)%s*$")
+      if not first then
+        table.insert(inlines, pandoc.Str(","))
+        table.insert(inlines, pandoc.Space())
+      end
+      first = false
+      local link_text = {
+        pandoc.Str(infer_prefix(target)),
+        pandoc.Space(),
+        pandoc.Str(target),
+      }
+      table.insert(inlines, pandoc.Link(link_text, "#" .. sanitize(target)))
+    end
+    if #inlines == 1 then return inlines[1] end
+    return pandoc.Span(inlines)
+  end
+
+  -- \caption{text}
+  local caption_text = text:match("^\\caption%s*{(.*)}$")
+  if caption_text then
+    return pandoc.Span(
+      {
+        pandoc.Strong(pandoc.Str("Caption:")),
+        pandoc.Space(),
+        pandoc.Str(caption_text),
+      },
+      make_attrs({"caption-text"})
+    )
+  end
+
+  return nil
+end
+
+function RawInline(inline)
+  if inline.format and inline.format:match("latex") then
+    local result = transform_latex_command(inline.text)
+    if result then return result end
+  end
+  return inline
+end

--- a/lagda_md/postprocess.py
+++ b/lagda_md/postprocess.py
@@ -1,0 +1,353 @@
+"""
+Postprocessor for the literate-Agda conversion pipeline.
+
+Takes Pandoc's GFM output (with the placeholder convention from
+`lagda_md.preprocess`) and produces the final `.lagda.md` content.
+The placeholder convention is documented in `lagda_md/__init__.py`.
+
+Always-on transformations:
+    * Code-block re-insertion: @@CODEBLOCK_ID_n@@ → fenced ```agda block.
+
+Opt-in transformations (each gated by a flag matching the corresponding
+flag passed to `lagda_md.preprocess.preprocess`):
+    * enable_cross_refs   — resolve @@CROSS_REF@@ markers via a label map.
+    * enable_theorem_envs — restore theorem/lemma/claim blocks.
+    * enable_figure_envs  — restore figure blocks as Markdown subsections.
+
+The label-map argument to `postprocess` is required when
+`enable_cross_refs=True`.  When converting a single file with cross-refs
+enabled, the user is responsible for supplying the map; the
+`build_label_map` helper builds one from a list of preprocessor outputs.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from functools import reduce
+from pathlib import Path
+from typing import Callable, Mapping
+
+__all__ = ["postprocess", "build_label_map"]
+
+
+def _unescape_from_placeholder(text: str) -> str:
+    """Reverse the @@ → @ @ escape applied by lagda_md.preprocess."""
+    return text.replace("@ @", "@@")
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+def postprocess(
+    intermediate_md: str,
+    code_blocks: Mapping[str, dict],
+    *,
+    label_map: Mapping[str, Mapping[str, str]] | None = None,
+    enable_cross_refs: bool = False,
+    enable_theorem_envs: bool = False,
+    enable_figure_envs: bool = False,
+) -> str:
+    """Apply postprocessing to Pandoc's intermediate Markdown output.
+
+    Args:
+        intermediate_md: The Markdown text produced by Pandoc + the package's
+            Lua filter.
+        code_blocks: The code-blocks dict returned by `lagda_md.preprocess`.
+        label_map: Required when `enable_cross_refs=True`.  Maps label IDs to
+            dicts of the form `{"file": str, "anchor": str, "caption_text": str}`.
+            Build one with `build_label_map`.
+        enable_cross_refs: If True, resolve @@CROSS_REF@@ placeholders.  Must
+            be the same value passed to `preprocess` for the same file.
+        enable_theorem_envs: If True, restore @@..._BLOCK@@ theorem placeholders.
+        enable_figure_envs: If True, restore @@FIGURE_BLOCK@@ placeholders.
+
+    Returns:
+        The final `.lagda.md` content.
+    """
+    if enable_cross_refs and label_map is None:
+        raise ValueError(
+            "enable_cross_refs=True requires a label_map; "
+            "use lagda_md.postprocess.build_label_map to construct one"
+        )
+
+    transformations: list[Callable[[str], str]] = [
+        lambda c: _restore_code_blocks(c, code_blocks),
+    ]
+    if enable_figure_envs:
+        transformations.append(_restore_figure_blocks)
+    if enable_theorem_envs:
+        transformations.append(_restore_theorem_blocks)
+    if enable_cross_refs:
+        assert label_map is not None  # validated above
+        transformations.append(lambda c: _resolve_cross_refs(c, label_map))
+
+    return reduce(lambda content, step: step(content), transformations, intermediate_md)
+
+
+# ---------------------------------------------------------------------------
+# Always-on: code-block re-insertion
+# ---------------------------------------------------------------------------
+_CODEBLOCK_PATTERN = re.compile(r"@@CODEBLOCK_ID_\d+@@")
+
+
+def _restore_code_blocks(content: str, code_blocks: Mapping[str, dict]) -> str:
+    """Replace each @@CODEBLOCK_ID_n@@ with its corresponding fenced block.
+
+    Hidden blocks (those captured from `\\begin{code}[hide]`) are wrapped
+    in HTML comments so they're type-checked by Agda but invisible by
+    default in the rendered Markdown.
+    """
+    def _replace(match: re.Match) -> str:
+        placeholder = match.group(0)
+        block = code_blocks.get(placeholder, {})
+        body = block.get("content", "").rstrip() + "\n"
+        if block.get("hidden", False):
+            return f"\n<!--\n```agda\n{body}```\n-->\n"
+        return f"\n```agda\n{body}```\n"
+
+    return _CODEBLOCK_PATTERN.sub(_replace, content)
+
+
+# ---------------------------------------------------------------------------
+# Opt-in: cross-references
+# ---------------------------------------------------------------------------
+_CROSSREF_PATTERN = re.compile(
+    r"@@CROSS_REF@@command=(.*?)@@targets=(.*?)@@",
+    flags=re.DOTALL,
+)
+
+
+def _resolve_cross_refs(
+    content: str, label_map: Mapping[str, Mapping[str, str]]
+) -> str:
+    """Resolve each @@CROSS_REF@@ placeholder against the label map."""
+    def _replace(match: re.Match) -> str:
+        targets_str = _unescape_from_placeholder(match.group(2))
+        labels = [t.strip() for t in targets_str.split(",") if t.strip()]
+        return _format_cross_ref_links(labels, label_map)
+
+    return _CROSSREF_PATTERN.sub(_replace, content)
+
+
+def _format_cross_ref_links(
+    labels: list[str], label_map: Mapping[str, Mapping[str, str]]
+) -> str:
+    """Format a list of label IDs as a chain of Markdown links joined by 'and'."""
+    parts: list[str] = []
+    for label_id in labels:
+        target = label_map.get(label_id)
+        if target is None:
+            parts.append(f"*'{label_id}' (unresolved reference)*")
+            logging.warning("Unresolved cross-reference: %r", label_id)
+            continue
+
+        caption = target.get("caption_text", label_id)
+        display = caption.replace("-", " ")
+        target_file = target.get("file", "")
+        anchor = target.get("anchor", "")
+
+        if target_file and anchor:
+            parts.append(f"Section [{display}]({target_file}{anchor})")
+        else:
+            parts.append(f"*Section {display} (link generation error)*")
+            logging.warning(
+                "Cross-reference %r resolved but missing file/anchor", label_id
+            )
+
+    return " and ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Opt-in: theorem / lemma / claim blocks
+# ---------------------------------------------------------------------------
+_THEOREM_BLOCK_LABELED = re.compile(
+    r"@@(THEOREM|LEMMA|CLAIM)_BLOCK@@label=(.*?)@@title=(.*?)@@\n(.*?)(?=\n@@|\Z)",
+    flags=re.DOTALL,
+)
+_THEOREM_BLOCK_UNLABELED = re.compile(
+    r"@@(THEOREM|LEMMA|CLAIM)_BLOCK@@title=(.*?)@@\n(.*?)(?=\n@@|\Z)",
+    flags=re.DOTALL,
+)
+
+
+def _restore_theorem_blocks(content: str) -> str:
+    """Restore theorem/lemma/claim placeholders to styled Markdown blocks."""
+    content = _THEOREM_BLOCK_LABELED.sub(
+        lambda m: _format_theorem_block(
+            m.group(1).lower(),
+            _unescape_from_placeholder(m.group(2)),
+            _unescape_from_placeholder(m.group(3)),
+            m.group(4),
+        ),
+        content,
+    )
+    content = _THEOREM_BLOCK_UNLABELED.sub(
+        lambda m: _format_theorem_block(
+            m.group(1).lower(),
+            "",
+            _unescape_from_placeholder(m.group(2)),
+            m.group(3),
+        ),
+        content,
+    )
+    return content
+
+
+def _format_theorem_block(kind: str, label: str, title: str, body: str) -> str:
+    """Format one theorem-like block as Markdown with optional anchor."""
+    anchor = f'<a id="{label}"></a>\n' if label else ""
+    heading = f"**{kind.capitalize()} ({title.strip(': ').strip()}).**"
+    return f"{anchor}{heading}\n\n{body.strip()}\n"
+
+
+# ---------------------------------------------------------------------------
+# Opt-in: figures
+# ---------------------------------------------------------------------------
+_FIGURE_LABELED_PATTERN = re.compile(
+    r"@@FIGURE_BLOCK_TO_SUBSECTION@@label=(.*?)@@caption=(.*?)@@",
+    flags=re.DOTALL,
+)
+_FIGURE_UNLABELED_PATTERN = re.compile(
+    r"@@UNLABELLED_FIGURE_CAPTION@@caption=(.*?)@@",
+    flags=re.DOTALL,
+)
+
+
+def _restore_figure_blocks(content: str) -> str:
+    """Restore figure placeholders as Markdown H3 headings."""
+    content = _FIGURE_LABELED_PATTERN.sub(
+        lambda m: _format_figure_subsection(_unescape_from_placeholder(m.group(2))),
+        content,
+    )
+    content = _FIGURE_UNLABELED_PATTERN.sub(
+        lambda m: _format_figure_subsection(_unescape_from_placeholder(m.group(1))),
+        content,
+    )
+    return content
+
+
+def _format_figure_subsection(caption: str) -> str:
+    """Format a figure caption as an H3 heading."""
+    cleaned = caption.replace("-", " ")
+    squashed = re.sub(r"\s+", " ", cleaned).strip()
+    return f"\n### {squashed}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference label map: extraction and helpers
+# ---------------------------------------------------------------------------
+_LABEL_FIGURE_PATTERN = re.compile(
+    r"@@FIGURE_BLOCK_TO_SUBSECTION@@label=(.*?)@@caption=(.*?)@@",
+    flags=re.DOTALL,
+)
+_LABEL_THEOREM_PATTERN = re.compile(
+    r"@@(THEOREM|LEMMA|CLAIM)_BLOCK@@label=(.*?)@@title=(.*?)@@",
+    flags=re.DOTALL,
+)
+_LABEL_SECTION_LABEL_PATTERN = re.compile(r"\\label\{(.*?)\}")
+_LABEL_SECTION_HEADING_PATTERN = re.compile(r"\\section\*?\{(.+?)\}", flags=re.DOTALL)
+
+
+def build_label_map(
+    sources: Mapping[Path, str],
+    *,
+    source_root: Path | None = None,
+) -> dict[str, dict[str, str]]:
+    """Build a cross-reference label map from preprocessor outputs.
+
+    Args:
+        sources: Mapping from a `.lagda` source path to the corresponding
+            preprocessor output (the placeholder-bearing string returned by
+            `lagda_md.preprocess.preprocess`).
+        source_root: Optional path used to compute each entry's `file` value
+            relative to the project root.  When None, the file's basename is
+            used.
+
+    Returns:
+        A dict mapping label IDs to `{"file": str, "anchor": str,
+        "caption_text": str}`.  Suitable for passing as `label_map=` to
+        `postprocess`.
+    """
+    label_map: dict[str, dict[str, str]] = {}
+
+    for source_path, content in sources.items():
+        relative = (
+            source_path.relative_to(source_root)
+            if source_root is not None
+            else Path(source_path.name)
+        )
+        flat_filename = _get_flat_filename(relative)
+
+        for match in _LABEL_FIGURE_PATTERN.finditer(content):
+            label_id = _unescape_from_placeholder(match.group(1))
+            caption = _unescape_from_placeholder(match.group(2))
+            label_map[label_id] = {
+                "file": flat_filename,
+                "anchor": f"#{_slugify(caption)}",
+                "caption_text": caption,
+            }
+
+        for match in _LABEL_THEOREM_PATTERN.finditer(content):
+            kind = match.group(1).capitalize()
+            label_id = _unescape_from_placeholder(match.group(2))
+            title = _unescape_from_placeholder(match.group(3))
+            label_map[label_id] = {
+                "file": flat_filename,
+                "anchor": f"#{label_id}",
+                "caption_text": f"{kind} ({title.strip(': ')})",
+            }
+
+        for match in _LABEL_SECTION_LABEL_PATTERN.finditer(content):
+            label_id = _unescape_from_placeholder(match.group(1))
+            before = content[: match.start()]
+            section_matches = list(_LABEL_SECTION_HEADING_PATTERN.finditer(before))
+            section_title = (
+                section_matches[-1].group(1).strip() if section_matches else label_id
+            )
+            label_map[label_id] = {
+                "file": flat_filename,
+                "anchor": f"#{label_id}",
+                "caption_text": section_title,
+            }
+
+    return label_map
+
+
+def _slugify(text: str | None) -> str:
+    """Generate a slug from text, similar to Python-Markdown's default behavior."""
+    if not text:
+        return "section"
+    slug = str(text).lower()
+    slug = re.sub(r"[^\w\s-]", "", slug).strip()
+    slug = re.sub(r"[-\s]+", "-", slug)
+    return slug or "section"
+
+
+def _get_flat_filename(relative_path: Path) -> str:
+    """Compute a flat 'ModuleName.md' filename from a relative path.
+
+    Handles `.lagda` and `.lagda.md` double extensions as well as `index`
+    files; mirrors the FLS pipeline's flattening convention so cross-references
+    resolve in MkDocs sites that use the same scheme.
+    """
+    name = relative_path.name
+    if name.endswith(".lagda.md"):
+        stem = name[: -len(".lagda.md")]
+    elif name.endswith(".lagda"):
+        stem = name[: -len(".lagda")]
+    else:
+        stem = relative_path.stem
+
+    parts = list(relative_path.parent.parts)
+    is_index = stem.lower() == "index"
+
+    if not parts and is_index:
+        flat_name = "index"
+    elif not parts:
+        flat_name = stem
+    else:
+        if not is_index:
+            parts.append(stem)
+        flat_name = ".".join(parts)
+
+    return f"{flat_name}.md"

--- a/lagda_md/postprocess.py
+++ b/lagda_md/postprocess.py
@@ -29,6 +29,7 @@ from typing import Callable, Mapping
 
 __all__ = ["postprocess", "build_label_map"]
 
+logger = logging.getLogger(__name__)
 
 def _unescape_from_placeholder(text: str) -> str:
     """Reverse the @@ → @ @ escape applied by lagda_md.preprocess."""
@@ -138,7 +139,7 @@ def _format_cross_ref_links(
         target = label_map.get(label_id)
         if target is None:
             parts.append(f"*'{label_id}' (unresolved reference)*")
-            logging.warning("Unresolved cross-reference: %r", label_id)
+            logger.warning("Unresolved cross-reference: %r", label_id)
             continue
 
         caption = target.get("caption_text", label_id)
@@ -150,7 +151,7 @@ def _format_cross_ref_links(
             parts.append(f"Section [{display}]({target_file}{anchor})")
         else:
             parts.append(f"*Section {display} (link generation error)*")
-            logging.warning(
+            logger.warning(
                 "Cross-reference %r resolved but missing file/anchor", label_id
             )
 

--- a/lagda_md/tests/test_postprocess.py
+++ b/lagda_md/tests/test_postprocess.py
@@ -1,0 +1,299 @@
+"""Tests for lagda_md.postprocess."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lagda_md.postprocess import build_label_map, postprocess
+from lagda_md.preprocess import preprocess
+
+
+# ---------------------------------------------------------------------------
+# Always-on: code-block restoration
+# ---------------------------------------------------------------------------
+class TestCodeBlockRestoration:
+    def test_visible_block_restored_as_fenced(self):
+        intermediate = "Some prose.\n\n@@CODEBLOCK_ID_1@@\n\nMore prose.\n"
+        blocks = {
+            "@@CODEBLOCK_ID_1@@": {"content": "data ⊤ : Set\n", "hidden": False}
+        }
+        result = postprocess(intermediate, blocks)
+        assert "```agda" in result
+        assert "data ⊤ : Set" in result
+        assert "@@CODEBLOCK_ID_1@@" not in result
+
+    def test_hidden_block_wrapped_in_html_comments(self):
+        intermediate = "Prose. @@CODEBLOCK_ID_1@@ More.\n"
+        blocks = {
+            "@@CODEBLOCK_ID_1@@": {
+                "content": "open import Foo\n",
+                "hidden": True,
+            }
+        }
+        result = postprocess(intermediate, blocks)
+        assert "<!--" in result
+        assert "```agda" in result
+        assert "open import Foo" in result
+        assert "-->" in result
+
+    def test_multiple_blocks_restored_in_order(self):
+        intermediate = "@@CODEBLOCK_ID_1@@\n\n@@CODEBLOCK_ID_2@@\n"
+        blocks = {
+            "@@CODEBLOCK_ID_1@@": {"content": "A\n", "hidden": False},
+            "@@CODEBLOCK_ID_2@@": {"content": "B\n", "hidden": False},
+        }
+        result = postprocess(intermediate, blocks)
+        assert result.index("A") < result.index("B")
+
+    def test_unknown_placeholder_renders_empty_block(self):
+        intermediate = "@@CODEBLOCK_ID_99@@"
+        result = postprocess(intermediate, {})
+        assert "```agda" in result
+
+
+# ---------------------------------------------------------------------------
+# Round-trip with preprocess
+# ---------------------------------------------------------------------------
+class TestPreprocessPostprocessRoundTrip:
+    def test_visible_code_block_round_trip(self):
+        original = (
+            "Some prose.\n"
+            "\\begin{code}\n"
+            "data ⊤ : Set where tt : ⊤\n"
+            "\\end{code}\n"
+            "More prose.\n"
+        )
+        intermediate, blocks = preprocess(original)
+        result = postprocess(intermediate, blocks)
+        assert "```agda" in result
+        assert "data ⊤ : Set where tt : ⊤" in result
+        assert "Some prose." in result
+        assert "More prose." in result
+
+    def test_hidden_code_block_round_trip(self):
+        original = (
+            "\\begin{code}[hide]\n"
+            "open import Universe\n"
+            "\\end{code}\n"
+        )
+        intermediate, blocks = preprocess(original)
+        result = postprocess(intermediate, blocks)
+        assert "<!--" in result
+        assert "open import Universe" in result
+
+
+# ---------------------------------------------------------------------------
+# Opt-in flags
+# ---------------------------------------------------------------------------
+class TestCrossRefsFlag:
+    def test_disabled_by_default(self):
+        intermediate = "See @@CROSS_REF@@command=Cref@@targets=sec:intro@@."
+        result = postprocess(intermediate, {})
+        assert "@@CROSS_REF@@" in result
+
+    def test_enabled_requires_label_map(self):
+        with pytest.raises(ValueError, match="label_map"):
+            postprocess("any content", {}, enable_cross_refs=True)
+
+    def test_enabled_resolves_known_label(self):
+        intermediate = "See @@CROSS_REF@@command=Cref@@targets=sec:intro@@."
+        label_map = {
+            "sec:intro": {
+                "file": "Intro.md",
+                "anchor": "#sec:intro",
+                "caption_text": "Introduction",
+            }
+        }
+        result = postprocess(
+            intermediate, {}, label_map=label_map, enable_cross_refs=True
+        )
+        assert "[Introduction](Intro.md#sec:intro)" in result
+        assert "Section " in result
+
+    def test_unresolved_label_yields_warning_marker(self, caplog):
+        intermediate = "See @@CROSS_REF@@command=Cref@@targets=sec:missing@@."
+        result = postprocess(
+            intermediate, {}, label_map={}, enable_cross_refs=True
+        )
+        assert "unresolved reference" in result
+        assert any("Unresolved" in r.message for r in caplog.records)
+
+    def test_multiple_targets_joined_with_and(self):
+        intermediate = "See @@CROSS_REF@@command=Cref@@targets=a,b@@."
+        label_map = {
+            "a": {"file": "X.md", "anchor": "#a", "caption_text": "A"},
+            "b": {"file": "X.md", "anchor": "#b", "caption_text": "B"},
+        }
+        result = postprocess(
+            intermediate, {}, label_map=label_map, enable_cross_refs=True
+        )
+        assert " and " in result
+        assert "[A](X.md#a)" in result
+        assert "[B](X.md#b)" in result
+
+
+class TestTheoremEnvsFlag:
+    def test_disabled_by_default(self):
+        intermediate = "@@THEOREM_BLOCK@@title=Birkhoff@@\nA proof body.\n"
+        result = postprocess(intermediate, {})
+        assert "@@THEOREM_BLOCK@@" in result
+
+    def test_enabled_renders_unlabeled_block(self):
+        intermediate = "@@THEOREM_BLOCK@@title=Birkhoff@@\nA proof body.\n"
+        result = postprocess(intermediate, {}, enable_theorem_envs=True)
+        assert "**Theorem (Birkhoff).**" in result
+        assert "A proof body." in result
+        assert "@@THEOREM_BLOCK@@" not in result
+
+    def test_enabled_renders_labeled_block_with_anchor(self):
+        intermediate = (
+            "@@LEMMA_BLOCK@@label=lem:useful@@title=Useful@@\n"
+            "Body of the lemma.\n"
+        )
+        result = postprocess(intermediate, {}, enable_theorem_envs=True)
+        assert '<a id="lem:useful"></a>' in result
+        assert "**Lemma (Useful).**" in result
+
+
+class TestFigureEnvsFlag:
+    def test_disabled_by_default(self):
+        intermediate = (
+            "@@FIGURE_BLOCK_TO_SUBSECTION@@label=fig:test@@caption=A-figure@@"
+        )
+        result = postprocess(intermediate, {})
+        assert "@@FIGURE_BLOCK_TO_SUBSECTION@@" in result
+
+    def test_enabled_labeled_figure_renders_as_subsection(self):
+        intermediate = (
+            "@@FIGURE_BLOCK_TO_SUBSECTION@@label=fig:test@@caption=A-figure@@"
+        )
+        result = postprocess(intermediate, {}, enable_figure_envs=True)
+        assert "### A figure" in result
+        assert "@@" not in result
+
+    def test_enabled_unlabeled_figure_renders_as_subsection(self):
+        intermediate = "@@UNLABELLED_FIGURE_CAPTION@@caption=Just-a-caption@@"
+        result = postprocess(intermediate, {}, enable_figure_envs=True)
+        assert "### Just a caption" in result
+
+
+# ---------------------------------------------------------------------------
+# Placeholder escape symmetry
+# ---------------------------------------------------------------------------
+class TestPlaceholderEscapeRoundTrip:
+    def test_at_at_in_cross_ref_target_round_trips(self):
+        # If a label ID contains @@, preprocess escapes it to @ @ on the way
+        # in.  postprocess must reverse the escape so the resolved label
+        # matches the original key in the label map.
+        intermediate = "See @@CROSS_REF@@command=Cref@@targets=sec:foo@ @bar@@."
+        label_map = {
+            "sec:foo@@bar": {
+                "file": "X.md",
+                "anchor": "#sec:foo_bar",
+                "caption_text": "Section title",
+            }
+        }
+        result = postprocess(
+            intermediate, {}, label_map=label_map, enable_cross_refs=True
+        )
+        assert "Section title" in result
+        assert "unresolved reference" not in result
+
+    def test_at_at_in_theorem_label_round_trips(self):
+        intermediate = (
+            "@@LEMMA_BLOCK@@label=lem:weird@ @case@@title=Useful@@\n"
+            "Body.\n"
+        )
+        result = postprocess(intermediate, {}, enable_theorem_envs=True)
+        # The label survives unescaping into the HTML anchor.
+        assert '<a id="lem:weird@@case"></a>' in result
+
+
+# ---------------------------------------------------------------------------
+# Label-map construction
+# ---------------------------------------------------------------------------
+class TestBuildLabelMap:
+    def test_empty_sources(self):
+        assert build_label_map({}) == {}
+
+    def test_collects_labeled_figure(self):
+        sources = {
+            Path("foo.lagda"): (
+                "Some prose.\n"
+                "@@FIGURE_BLOCK_TO_SUBSECTION@@label=fig:diagram@@caption=My-Diagram@@\n"
+                "More prose.\n"
+            )
+        }
+        m = build_label_map(sources)
+        assert "fig:diagram" in m
+        assert m["fig:diagram"]["caption_text"] == "My-Diagram"
+        assert m["fig:diagram"]["file"] == "foo.md"
+
+    def test_collects_labeled_theorem(self):
+        sources = {
+            Path("foo.lagda"): (
+                "@@THEOREM_BLOCK@@label=thm:big@@title=Big@@\nBody.\n"
+            )
+        }
+        m = build_label_map(sources)
+        assert "thm:big" in m
+        assert "Theorem (Big)" in m["thm:big"]["caption_text"]
+
+    def test_uses_relative_path_from_source_root(self, tmp_path: Path):
+        src_root = tmp_path
+        src_file = src_root / "Sub" / "Module.lagda"
+        sources = {
+            src_file: (
+                "@@THEOREM_BLOCK@@label=thm:foo@@title=Foo@@\nBody.\n"
+            )
+        }
+        m = build_label_map(sources, source_root=src_root)
+        assert m["thm:foo"]["file"] == "Sub.Module.md"
+
+    def test_section_label_resolves_to_preceding_heading(self):
+        sources = {
+            Path("foo.lagda"): (
+                "\\section{Introduction}\n"
+                "Some prose.\n"
+                "\\label{sec:intro}\n"
+                "More prose.\n"
+            )
+        }
+        m = build_label_map(sources)
+        assert "sec:intro" in m
+        assert m["sec:intro"]["caption_text"] == "Introduction"
+
+    def test_unescapes_at_at_in_label_id(self):
+        sources = {
+            Path("foo.lagda"): (
+                "@@THEOREM_BLOCK@@label=thm:weird@ @case@@title=Foo@@\nBody.\n"
+            )
+        }
+        m = build_label_map(sources)
+        assert "thm:weird@@case" in m
+
+
+# ---------------------------------------------------------------------------
+# agda-algebras shape
+# ---------------------------------------------------------------------------
+class TestAgdaAlgebrasShape:
+    """Sanity check: code-only corpus with no opt-in flags."""
+
+    def test_minimal_pipeline_passes_through_prose(self):
+        original = (
+            "Some prose with no LaTeX commands.\n"
+            "\\begin{code}\n"
+            "open import Level using ( Level )\n"
+            "\\end{code}\n"
+            "More prose.\n"
+        )
+        intermediate, blocks = preprocess(original)
+        result = postprocess(intermediate, blocks)
+
+        assert "Some prose with no LaTeX commands." in result
+        assert "More prose." in result
+        assert "open import Level using ( Level )" in result
+        assert "```agda" in result
+        for marker in ("@@CROSS_REF@@", "@@THEOREM_BLOCK@@", "@@FIGURE_BLOCK"):
+            assert marker not in result

--- a/lagda_md/tests/test_postprocess.py
+++ b/lagda_md/tests/test_postprocess.py
@@ -117,7 +117,7 @@ class TestCrossRefsFlag:
             intermediate, {}, label_map={}, enable_cross_refs=True
         )
         assert "unresolved reference" in result
-        assert any("Unresolved" in r.message for r in caplog.records)
+        assert any("Unresolved" in r.getMessage() for r in caplog.records)
 
     def test_multiple_targets_joined_with_and(self):
         intermediate = "See @@CROSS_REF@@command=Cref@@targets=a,b@@."
@@ -297,3 +297,25 @@ class TestAgdaAlgebrasShape:
         assert "```agda" in result
         for marker in ("@@CROSS_REF@@", "@@THEOREM_BLOCK@@", "@@FIGURE_BLOCK"):
             assert marker not in result
+
+class TestLuaFilterEscapeRoundTrip:
+    """The agda-filter.lua filter must unescape @ @ back to @@ in payloads.
+
+    These tests verify the *parsing* of payloads with escaped @-characters
+    inside values; the actual Lua filter is exercised end-to-end only when
+    Pandoc is invoked.  Here we confirm that preprocess emits a payload
+    that the new parsing strategy can recover correctly.
+    """
+
+    def test_at_at_in_basename_survives_escape_through_preprocess(self):
+        # The preprocessor escapes @@ -> @ @ inside placeholder values, so a
+        # macro basename containing literal @@ produces a payload with @ @
+        # inside the basename field but plain @@ as the field separators.
+        # This regressed under the old Lua parser because [^@]+ truncated
+        # at the first single @.
+        text, _ = preprocess(r"\AgdaModule{Foo@@Bar}")
+        assert "@@AgdaTerm@@basename=Foo@ @Bar@@class=AgdaModule@@" in text
+        # Field separator: every @@ that's part of the placeholder grammar.
+        # Escaped value:    every @ @ that was once an @@ in user content.
+        # The Lua filter must distinguish them; if it doesn't, the basename
+        # truncates to "Foo" and we lose data.


### PR DESCRIPTION
Implements #3.  Pairs symmetrically with `lagda_md.preprocess` (#2): every placeholder convention introduced by preprocess has a corresponding restoration step in postprocess, gated by the same opt-in flags.

The full FLS pipeline at `examples/fls-pipeline/` is unchanged; `lagda_md/` continues to hold only the universal subset.

## Departure from #3's issue body

The issue body proposed a separate `lagda_md/labels.py` module for cross-reference label-map construction.  After implementing the reorganization in #1 and the preprocessor in #2, I reconsidered and lifted `extract_labels` into `postprocess.py` as a public `build_label_map` helper rather than splitting it into its own module.  Two reasons: (a) the function is the natural input to `postprocess` when `enable_cross_refs=True`, so it lives next to its caller; (b) keeping the package surface tight (four exports: `preprocess`, `postprocess`, `build_label_map`, `MacroTable`) is preferable to growing it with single-function modules until users actually need the granularity.  If a future user wants the label extractor in isolation, lifting it to its own module is a one-line `__init__.py` change.

## Notes for review

+  **Escape symmetry baked in from the start.**  The @@-escape fix that landed in #8's review is now mirrored in postprocess: `_unescape_from_placeholder` is applied at every placeholder-extraction site, including inside `build_label_map`.  Two new tests under `TestPlaceholderEscapeRoundTrip` exercise the round-trip.
+  **Lua filter slimming.**  The default `lagda_md/filters/agda-filter.lua` is 60 lines (down from 257 in the FLS version), handling only `@@AgdaTerm@@` markers and unescaping their payloads.  All other FLS-specific Lua code (HighlightPlaceholder etc.) remains in `examples/fls-pipeline/agda-filter.lua`.
+  **Cross-refs as an opt-in second filter.**  Projects using `\label` / `\Cref` / `\caption` get those handlers via `lagda_md/filters/cross-refs.lua`, which the CLI in #4 will load only when the user passes `--enable-cross-refs`.

Closes #3.
