### PR TITLE
Implement convert_lagda.py CLI and lagda_md.core entry point

### DIFF
--- a/convert_lagda.py
+++ b/convert_lagda.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Convenience wrapper for ``python3 -m lagda_md``.
+
+This script lets you run the converter as ``./convert_lagda.py ...``
+without installing the package.  Equivalent to ``python3 -m lagda_md``.
+"""
+from __future__ import annotations
+
+import sys
+
+from lagda_md.cli import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lagda_md/__init__.py
+++ b/lagda_md/__init__.py
@@ -41,5 +41,15 @@ contain `@@` safely.
 from .macros import MacroEntry, MacroTable
 from .preprocess import preprocess
 from .postprocess import postprocess, build_label_map
+from .core import ConversionError, convert_file, convert_tree
 
-__all__ = ["MacroEntry", "MacroTable", "preprocess", "postprocess", "build_label_map"]
+__all__ = [
+    "ConversionError",
+    "MacroEntry",
+    "MacroTable",
+    "build_label_map",
+    "convert_file",
+    "convert_tree",
+    "postprocess",
+    "preprocess",
+]

--- a/lagda_md/__main__.py
+++ b/lagda_md/__main__.py
@@ -1,0 +1,10 @@
+"""Allow `python3 -m lagda_md` to invoke the CLI."""
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lagda_md/cli.py
+++ b/lagda_md/cli.py
@@ -19,7 +19,15 @@ __all__ = ["main"]
 def main(argv: list[str] | None = None) -> int:
     """Parse arguments and dispatch to the appropriate conversion mode.
 
-    Returns 0 on success, 1 on usage errors, 2 on conversion failures.
+    Return values:
+        0: success.
+        1: argument-validation failure (e.g., --in-tree without --out-tree).
+        2: conversion failure (e.g., Pandoc returned a nonzero exit code).
+
+    `argparse` parser errors (unknown flags, invalid values) raise
+    `SystemExit(2)` per the standard library convention, bypassing this
+    return-code path; callers wishing to recover from parse errors must
+    catch `SystemExit` explicitly.
     """
     parser = _build_parser()
     args = parser.parse_args(argv)
@@ -35,6 +43,13 @@ def main(argv: list[str] | None = None) -> int:
     extra_filters = [Path(f) for f in args.extra_filter or ()]
 
     if args.in_tree:
+        if args.check:
+            print(
+                "error: --check is currently single-file-only; "
+                "use --check on individual files instead of with --in-tree",
+                file=sys.stderr,
+            )
+            return 1
         if args.out_tree is None:
             print("error: --in-tree requires --out-tree", file=sys.stderr)
             return 1

--- a/lagda_md/cli.py
+++ b/lagda_md/cli.py
@@ -1,0 +1,256 @@
+"""
+Command-line interface for lagda_md.
+
+Invoked via `python3 -m lagda_md ...` or directly as `convert_lagda.py ...`.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from .core import convert_file, convert_tree
+from .macros import MacroTable
+
+__all__ = ["main"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and dispatch to the appropriate conversion mode.
+
+    Returns 0 on success, 1 on usage errors, 2 on conversion failures.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    macros = (
+        MacroTable.from_json(args.macros) if args.macros else MacroTable.default()
+    )
+    extra_filters = [Path(f) for f in args.extra_filter or ()]
+
+    if args.in_tree:
+        if args.out_tree is None:
+            print("error: --in-tree requires --out-tree", file=sys.stderr)
+            return 1
+        return _run_tree_mode(args, macros, extra_filters)
+    if args.input is None:
+        print("error: INPUT is required unless --in-tree is given", file=sys.stderr)
+        return 1
+    if args.check:
+        return _run_check_mode(args, macros, extra_filters)
+    if args.output is None:
+        print("error: OUTPUT is required for single-file conversion", file=sys.stderr)
+        return 1
+    return _run_single_mode(args, macros, extra_filters)
+
+
+# ---------------------------------------------------------------------------
+# Mode dispatchers
+# ---------------------------------------------------------------------------
+def _run_single_mode(
+    args: argparse.Namespace, macros: MacroTable, extra_filters: list[Path]
+) -> int:
+    """Single-file conversion."""
+    try:
+        convert_file(
+            args.input,
+            args.output,
+            macros=macros,
+            enable_cross_refs=args.enable_cross_refs,
+            enable_theorem_envs=args.enable_theorem_envs,
+            enable_figure_envs=args.enable_figure_envs,
+            label_map=None,  # cross-refs across files not meaningful in single mode
+            extra_lua_filters=extra_filters,
+            pandoc=args.pandoc,
+            keep_temp=args.keep_temp,
+        )
+    except ValueError as e:
+        # enable_cross_refs without a label map; fall through with a hint.
+        print(f"error: {e}", file=sys.stderr)
+        print(
+            "hint: cross-references can only be resolved across a tree; "
+            "use --in-tree mode for a multi-file project",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as e:
+        print(f"error: conversion failed: {e}", file=sys.stderr)
+        return 2
+
+    print(f"wrote {args.output}")
+    return 0
+
+
+def _run_tree_mode(
+    args: argparse.Namespace, macros: MacroTable, extra_filters: list[Path]
+) -> int:
+    """Whole-tree conversion."""
+    in_root: Path = args.in_tree
+    out_root: Path = args.out_tree
+
+    if not in_root.is_dir():
+        print(f"error: {in_root} is not a directory", file=sys.stderr)
+        return 1
+
+    inputs = sorted(in_root.rglob("*.lagda"))
+    if not inputs:
+        print(f"error: no .lagda files found under {in_root}", file=sys.stderr)
+        return 1
+
+    print(f"found {len(inputs)} .lagda files under {in_root}")
+
+    succeeded, failed = convert_tree(
+        inputs,
+        in_root=in_root,
+        out_root=out_root,
+        macros=macros,
+        enable_cross_refs=args.enable_cross_refs,
+        enable_theorem_envs=args.enable_theorem_envs,
+        enable_figure_envs=args.enable_figure_envs,
+        extra_lua_filters=extra_filters,
+        pandoc=args.pandoc,
+        keep_temp=args.keep_temp,
+    )
+
+    print(f"converted {len(succeeded)} of {len(inputs)} files")
+    if failed:
+        print(f"failures ({len(failed)}):", file=sys.stderr)
+        for src, exc in failed:
+            print(f"  {src}: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def _run_check_mode(
+    args: argparse.Namespace, macros: MacroTable, extra_filters: list[Path]
+) -> int:
+    """Validate that conversion would succeed, without writing output."""
+    import tempfile
+
+    # Use a throwaway output path under a temp dir.
+    with tempfile.TemporaryDirectory() as tmp:
+        scratch_output = Path(tmp) / "scratch.lagda.md"
+        try:
+            convert_file(
+                args.input,
+                scratch_output,
+                macros=macros,
+                enable_cross_refs=False,
+                enable_theorem_envs=args.enable_theorem_envs,
+                enable_figure_envs=args.enable_figure_envs,
+                label_map=None,
+                extra_lua_filters=extra_filters,
+                pandoc=args.pandoc,
+                keep_temp=False,
+            )
+        except Exception as e:
+            print(f"check failed: {e}", file=sys.stderr)
+            return 2
+
+    print(f"check passed: {args.input} would convert successfully")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="convert_lagda",
+        description=(
+            "Convert LaTeX-literate Agda (.lagda) to Markdown-literate Agda "
+            "(.lagda.md), via a four-stage pipeline of preprocessing, "
+            "Pandoc, a Lua filter, and postprocessing."
+        ),
+    )
+
+    parser.add_argument(
+        "input",
+        nargs="?",
+        type=Path,
+        help="Input .lagda file (required for single-file or --check mode)",
+    )
+    parser.add_argument(
+        "output",
+        nargs="?",
+        type=Path,
+        help="Output .lagda.md file (required for single-file mode)",
+    )
+
+    tree = parser.add_argument_group("tree mode")
+    tree.add_argument(
+        "--in-tree",
+        type=Path,
+        metavar="DIR",
+        help="Convert every .lagda under DIR (recursive).",
+    )
+    tree.add_argument(
+        "--out-tree",
+        type=Path,
+        metavar="DIR",
+        help="Write outputs to DIR, mirroring the input directory structure.",
+    )
+
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Run conversion without writing output; exit 0 on success.",
+    )
+
+    customization = parser.add_argument_group("customization")
+    customization.add_argument(
+        "--macros",
+        type=Path,
+        metavar="FILE",
+        help="Path to a JSON macro table.  Default: the package-bundled default.",
+    )
+    customization.add_argument(
+        "--extra-filter",
+        action="append",
+        metavar="FILE",
+        help="Additional Pandoc Lua filter to layer on the defaults.  Repeat for multiple.",
+    )
+
+    optins = parser.add_argument_group("opt-in transformations")
+    optins.add_argument(
+        "--enable-cross-refs",
+        action="store_true",
+        help=r"Resolve \Cref / \cref / \label / \caption (loads cross-refs.lua filter).",
+    )
+    optins.add_argument(
+        "--enable-theorem-envs",
+        action="store_true",
+        help=r"Restore \begin{theorem}, \begin{lemma}, \begin{claim} environments.",
+    )
+    optins.add_argument(
+        "--enable-figure-envs",
+        action="store_true",
+        help=r"Restore \begin{figure} environments as Markdown subsections.",
+    )
+
+    debug = parser.add_argument_group("debugging")
+    debug.add_argument(
+        "--pandoc",
+        default="pandoc",
+        metavar="EXEC",
+        help="Pandoc executable name (default: pandoc).",
+    )
+    debug.add_argument(
+        "--keep-temp",
+        action="store_true",
+        help="Preserve the temporary working directory after conversion.",
+    )
+    debug.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Verbose logging.",
+    )
+
+    return parser

--- a/lagda_md/core.py
+++ b/lagda_md/core.py
@@ -1,0 +1,290 @@
+"""
+Core conversion entry point.
+
+Wraps preprocess, Pandoc invocation, and postprocess into a single
+operation on one file.  The CLI in `convert_lagda.py` builds on this.
+
+`convert_file` is the per-file primitive.  `convert_tree` is a thin
+wrapper for whole-tree migration that handles cross-reference label-map
+construction in a two-pass fashion.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from .macros import MacroTable
+from .postprocess import build_label_map, postprocess
+from .preprocess import preprocess
+
+__all__ = ["ConversionError", "convert_file", "convert_tree"]
+
+logger = logging.getLogger(__name__)
+
+
+class ConversionError(RuntimeError):
+    """Raised when conversion fails for a specific file."""
+
+    def __init__(self, source: Path, stage: str, detail: str):
+        super().__init__(
+            f"conversion of {source} failed at {stage}: {detail}"
+        )
+        self.source = source
+        self.stage = stage
+        self.detail = detail
+
+
+# Default Lua filters bundled with the package.
+_BUNDLED_FILTERS_DIR = Path(__file__).parent / "filters"
+_DEFAULT_FILTER = _BUNDLED_FILTERS_DIR / "agda-filter.lua"
+_CROSSREFS_FILTER = _BUNDLED_FILTERS_DIR / "cross-refs.lua"
+
+
+@dataclass(frozen=True)
+class _ConversionOptions:
+    """Internal bundle of conversion options for a single file."""
+    macros: MacroTable
+    enable_cross_refs: bool
+    enable_theorem_envs: bool
+    enable_figure_envs: bool
+    extra_lua_filters: tuple[Path, ...]
+    pandoc: str  # the executable name, configurable for testing
+
+
+def convert_file(
+    input_path: Path,
+    output_path: Path,
+    *,
+    macros: MacroTable | None = None,
+    enable_cross_refs: bool = False,
+    enable_theorem_envs: bool = False,
+    enable_figure_envs: bool = False,
+    label_map: Mapping[str, Mapping[str, str]] | None = None,
+    extra_lua_filters: Iterable[Path] = (),
+    pandoc: str = "pandoc",
+    keep_temp: bool = False,
+) -> None:
+    """Convert one .lagda file to .lagda.md.
+
+    Args:
+        input_path: Path to the .lagda source.
+        output_path: Path where the .lagda.md result is written.  Parent
+            directories are created if they don't exist.
+        macros: Optional macro table.  Defaults to the package's default table.
+        enable_cross_refs: If True, resolve \\Cref / \\cref using label_map.
+        enable_theorem_envs: If True, restore theorem/lemma/claim placeholders.
+        enable_figure_envs: If True, restore figure placeholders.
+        label_map: Required when enable_cross_refs=True.  See `build_label_map`.
+        extra_lua_filters: Additional Lua filters layered on top of the
+            package defaults.  Used for project-specific extensions.
+        pandoc: Name of the Pandoc executable.  Override for testing.
+        keep_temp: If True, the temp directory is preserved (useful for
+            debugging Pandoc output).  Otherwise it is deleted.
+
+    Raises:
+        ConversionError: If any stage of the pipeline fails.
+        FileNotFoundError: If `input_path` doesn't exist.
+        ValueError: If enable_cross_refs=True but label_map=None.
+    """
+    if macros is None:
+        macros = MacroTable.default()
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"input file does not exist: {input_path}")
+    if enable_cross_refs and label_map is None:
+        raise ValueError(
+            "enable_cross_refs=True requires a label_map; "
+            "use lagda_md.postprocess.build_label_map to construct one"
+        )
+
+    options = _ConversionOptions(
+        macros=macros,
+        enable_cross_refs=enable_cross_refs,
+        enable_theorem_envs=enable_theorem_envs,
+        enable_figure_envs=enable_figure_envs,
+        extra_lua_filters=tuple(extra_lua_filters),
+        pandoc=pandoc,
+    )
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="lagda_md_"))
+    try:
+        _convert_one(input_path, output_path, options, label_map, temp_dir)
+    finally:
+        if not keep_temp:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+        else:
+            logger.info("kept temp dir for inspection: %s", temp_dir)
+
+
+def convert_tree(
+    inputs: Iterable[Path],
+    *,
+    in_root: Path,
+    out_root: Path,
+    macros: MacroTable | None = None,
+    enable_cross_refs: bool = False,
+    enable_theorem_envs: bool = False,
+    enable_figure_envs: bool = False,
+    extra_lua_filters: Iterable[Path] = (),
+    pandoc: str = "pandoc",
+    keep_temp: bool = False,
+) -> tuple[list[Path], list[tuple[Path, Exception]]]:
+    """Convert a tree of .lagda files into a parallel tree of .lagda.md files.
+
+    For projects using cross-references, this is the recommended entry
+    point: it does a first pass over every input to build the global
+    label map, then a second pass that runs each file's full pipeline
+    with that map in scope.  For projects without cross-references, only
+    the second pass is meaningful and the label map remains empty.
+
+    Args:
+        inputs: Iterable of input .lagda paths.
+        in_root: The directory under which input paths live.  Used to
+            compute output paths and label map keys.
+        out_root: The directory under which output paths are written.
+            Mirrors the input tree.
+        Other args: forwarded to `convert_file`.
+
+    Returns:
+        A tuple `(succeeded, failed)`.  `succeeded` is the list of output
+        paths written.  `failed` is a list of (input_path, exception) pairs.
+    """
+    if macros is None:
+        macros = MacroTable.default()
+
+    inputs = list(inputs)
+
+    # First pass for cross-refs: preprocess every file, collect outputs.
+    label_map: dict[str, dict[str, str]] = {}
+    if enable_cross_refs:
+        logger.info("first pass: building cross-reference label map")
+        preprocessed: dict[Path, str] = {}
+        for src in inputs:
+            try:
+                content = src.read_text(encoding="utf-8")
+                pre, _blocks = preprocess(
+                    content,
+                    macros=macros,
+                    enable_cross_refs=True,
+                    enable_theorem_envs=enable_theorem_envs,
+                    enable_figure_envs=enable_figure_envs,
+                )
+                preprocessed[src] = pre
+            except Exception as e:
+                logger.warning("preprocess failed for %s: %s", src, e)
+        label_map = build_label_map(preprocessed, source_root=in_root)
+        logger.info("collected %d label entries", len(label_map))
+
+    # Second pass: per-file conversion using the (possibly empty) label map.
+    succeeded: list[Path] = []
+    failed: list[tuple[Path, Exception]] = []
+    for src in inputs:
+        try:
+            relative = src.relative_to(in_root)
+            dst = out_root / relative.with_suffix("").with_suffix(".lagda.md")
+            convert_file(
+                src,
+                dst,
+                macros=macros,
+                enable_cross_refs=enable_cross_refs,
+                enable_theorem_envs=enable_theorem_envs,
+                enable_figure_envs=enable_figure_envs,
+                label_map=label_map if enable_cross_refs else None,
+                extra_lua_filters=extra_lua_filters,
+                pandoc=pandoc,
+                keep_temp=keep_temp,
+            )
+            succeeded.append(dst)
+        except Exception as e:
+            failed.append((src, e))
+            logger.warning("conversion failed for %s: %s", src, e)
+
+    return succeeded, failed
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+def _convert_one(
+    input_path: Path,
+    output_path: Path,
+    options: _ConversionOptions,
+    label_map: Mapping[str, Mapping[str, str]] | None,
+    temp_dir: Path,
+) -> None:
+    """The four-stage pipeline for one file."""
+    try:
+        content = input_path.read_text(encoding="utf-8")
+    except OSError as e:
+        raise ConversionError(input_path, "read", str(e)) from e
+
+    # Stage 1: preprocess.
+    try:
+        intermediate_text, code_blocks = preprocess(
+            content,
+            macros=options.macros,
+            enable_cross_refs=options.enable_cross_refs,
+            enable_theorem_envs=options.enable_theorem_envs,
+            enable_figure_envs=options.enable_figure_envs,
+        )
+    except Exception as e:
+        raise ConversionError(input_path, "preprocess", str(e)) from e
+
+    temp_input = temp_dir / "preprocessed.tex"
+    temp_output = temp_dir / "intermediate.md"
+    try:
+        temp_input.write_text(intermediate_text, encoding="utf-8")
+    except OSError as e:
+        raise ConversionError(input_path, "write-temp", str(e)) from e
+
+    # Stage 2: Pandoc + Lua filter(s).
+    filters = [_DEFAULT_FILTER]
+    if options.enable_cross_refs:
+        filters.append(_CROSSREFS_FILTER)
+    filters.extend(options.extra_lua_filters)
+
+    cmd = [options.pandoc, "-f", "latex", "-t", "gfm+attributes"]
+    for f in filters:
+        cmd.extend(["--lua-filter", str(f)])
+    cmd.extend(["-o", str(temp_output), str(temp_input)])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError as e:
+        raise ConversionError(input_path, "pandoc", f"executable not found: {options.pandoc}") from e
+    if result.returncode != 0:
+        raise ConversionError(
+            input_path,
+            "pandoc",
+            f"return code {result.returncode}: {result.stderr.strip()}",
+        )
+
+    # Stage 3: postprocess.
+    try:
+        intermediate_md = temp_output.read_text(encoding="utf-8")
+    except OSError as e:
+        raise ConversionError(input_path, "read-intermediate", str(e)) from e
+
+    try:
+        final = postprocess(
+            intermediate_md,
+            code_blocks,
+            label_map=label_map,
+            enable_cross_refs=options.enable_cross_refs,
+            enable_theorem_envs=options.enable_theorem_envs,
+            enable_figure_envs=options.enable_figure_envs,
+        )
+    except Exception as e:
+        raise ConversionError(input_path, "postprocess", str(e)) from e
+
+    # Stage 4: write output.
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        output_path.write_text(final, encoding="utf-8")
+    except OSError as e:
+        raise ConversionError(input_path, "write-output", str(e)) from e

--- a/lagda_md/tests/test_cli.py
+++ b/lagda_md/tests/test_cli.py
@@ -24,24 +24,26 @@ from lagda_md.core import ConversionError, convert_file, convert_tree
 # ---------------------------------------------------------------------------
 @pytest.fixture
 def fake_pandoc(tmp_path: Path) -> Path:
-    """A no-op Pandoc replacement that copies its --output's matching input."""
-    fake = tmp_path / "fake_pandoc.sh"
+    """A no-op Pandoc replacement that copies its --output's matching input.
+
+    Implemented as a Python script for portability across macOS, Linux, and
+    Windows; argparse handles flag parsing without bash-array gymnastics.
+    """
+    fake = tmp_path / "fake_pandoc.py"
     fake.write_text(
-        "#!/usr/bin/env bash\n"
-        "# Argument-parsing pandoc stand-in.  Reads -o for the output path,\n"
-        "# treats the last positional arg as the input.\n"
-        "out=\"\"\n"
-        "args=()\n"
-        "while [[ $# -gt 0 ]]; do\n"
-        "  case \"$1\" in\n"
-        "    -o) out=\"$2\"; shift 2 ;;\n"
-        "    --lua-filter) shift 2 ;;\n"
-        "    -f|-t) shift 2 ;;\n"
-        "    *) args+=(\"$1\"); shift ;;\n"
-        "  esac\n"
-        "done\n"
-        "in=\"${args[-1]}\"\n"
-        "cp \"$in\" \"$out\"\n",
+        "#!/usr/bin/env python3\n"
+        "import argparse\n"
+        "import shutil\n"
+        "import sys\n"
+        "\n"
+        "parser = argparse.ArgumentParser()\n"
+        "parser.add_argument('-o', '--output', required=True)\n"
+        "parser.add_argument('--lua-filter', action='append', default=[])\n"
+        "parser.add_argument('-f', '--from')\n"
+        "parser.add_argument('-t', '--to')\n"
+        "parser.add_argument('input')\n"
+        "args = parser.parse_args()\n"
+        "shutil.copyfile(args.input, args.output)\n",
         encoding="utf-8",
     )
     fake.chmod(fake.stat().st_mode | stat.S_IEXEC)
@@ -138,6 +140,8 @@ class TestConvertTree:
     def test_collects_failures_without_aborting(
         self, tmp_path: Path, fake_pandoc: Path
     ):
+        if not hasattr(os, "geteuid"):
+            pytest.skip("test relies on POSIX uid; not available on this platform")
         in_root = tmp_path / "in"
         out_root = tmp_path / "out"
         in_root.mkdir()
@@ -146,8 +150,7 @@ class TestConvertTree:
         )
 
         # Simulate a per-file failure by making the output path's parent
-        # un-writable.  (Skip the test if running as root, where chmod
-        # has no effect.)
+        # un-writable.
         if os.geteuid() == 0:
             pytest.skip("test relies on filesystem permissions; running as root")
         out_root.mkdir(mode=0o555)

--- a/lagda_md/tests/test_cli.py
+++ b/lagda_md/tests/test_cli.py
@@ -1,0 +1,222 @@
+"""Tests for lagda_md.cli and lagda_md.core.
+
+These tests use a fake Pandoc executable (a shell script that
+copies stdin to stdout, after the temp file is read) so the CLI
+runs end-to-end without depending on Pandoc being installed.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from lagda_md.cli import main
+from lagda_md.core import ConversionError, convert_file, convert_tree
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: a fake pandoc that just copies its input file to its
+# output file, so the four-stage pipeline runs without Pandoc installed.
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def fake_pandoc(tmp_path: Path) -> Path:
+    """A no-op Pandoc replacement that copies its --output's matching input."""
+    fake = tmp_path / "fake_pandoc.sh"
+    fake.write_text(
+        "#!/usr/bin/env bash\n"
+        "# Argument-parsing pandoc stand-in.  Reads -o for the output path,\n"
+        "# treats the last positional arg as the input.\n"
+        "out=\"\"\n"
+        "args=()\n"
+        "while [[ $# -gt 0 ]]; do\n"
+        "  case \"$1\" in\n"
+        "    -o) out=\"$2\"; shift 2 ;;\n"
+        "    --lua-filter) shift 2 ;;\n"
+        "    -f|-t) shift 2 ;;\n"
+        "    *) args+=(\"$1\"); shift ;;\n"
+        "  esac\n"
+        "done\n"
+        "in=\"${args[-1]}\"\n"
+        "cp \"$in\" \"$out\"\n",
+        encoding="utf-8",
+    )
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# convert_file — single-file behavior
+# ---------------------------------------------------------------------------
+class TestConvertFile:
+    def test_simple_file_round_trips(self, tmp_path: Path, fake_pandoc: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "Some prose.\n"
+            "\\begin{code}\n"
+            "data ⊤ : Set where tt : ⊤\n"
+            "\\end{code}\n",
+            encoding="utf-8",
+        )
+        convert_file(src, dst, pandoc=str(fake_pandoc))
+        assert dst.exists()
+        result = dst.read_text(encoding="utf-8")
+        assert "Some prose." in result
+        assert "data ⊤ : Set where tt : ⊤" in result
+        assert "```agda" in result
+
+    def test_creates_parent_directories(self, tmp_path: Path, fake_pandoc: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "out" / "subtree" / "Foo.lagda.md"
+        src.write_text("\\begin{code}\nfoo = 1\n\\end{code}\n", encoding="utf-8")
+        convert_file(src, dst, pandoc=str(fake_pandoc))
+        assert dst.exists()
+        assert dst.parent.is_dir()
+
+    def test_missing_input_raises(self, tmp_path: Path, fake_pandoc: Path):
+        with pytest.raises(FileNotFoundError):
+            convert_file(
+                tmp_path / "nope.lagda",
+                tmp_path / "out.lagda.md",
+                pandoc=str(fake_pandoc),
+            )
+
+    def test_pandoc_executable_missing_raises_conversion_error(
+        self, tmp_path: Path
+    ):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text("\\begin{code}\nfoo = 1\n\\end{code}\n", encoding="utf-8")
+        with pytest.raises(ConversionError, match="pandoc"):
+            convert_file(src, dst, pandoc="this-binary-does-not-exist")
+
+    def test_cross_refs_without_label_map_raises(
+        self, tmp_path: Path, fake_pandoc: Path
+    ):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text("trivial\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="label_map"):
+            convert_file(
+                src, dst, pandoc=str(fake_pandoc), enable_cross_refs=True
+            )
+
+
+# ---------------------------------------------------------------------------
+# convert_tree — whole-tree behavior
+# ---------------------------------------------------------------------------
+class TestConvertTree:
+    def test_mirrors_directory_structure(
+        self, tmp_path: Path, fake_pandoc: Path
+    ):
+        in_root = tmp_path / "in"
+        out_root = tmp_path / "out"
+        (in_root / "a").mkdir(parents=True)
+        (in_root / "b" / "c").mkdir(parents=True)
+        (in_root / "a" / "M1.lagda").write_text(
+            "\\begin{code}\nfoo = 1\n\\end{code}\n", encoding="utf-8"
+        )
+        (in_root / "b" / "c" / "M2.lagda").write_text(
+            "\\begin{code}\nbar = 2\n\\end{code}\n", encoding="utf-8"
+        )
+
+        succeeded, failed = convert_tree(
+            list(in_root.rglob("*.lagda")),
+            in_root=in_root,
+            out_root=out_root,
+            pandoc=str(fake_pandoc),
+        )
+        assert len(succeeded) == 2
+        assert len(failed) == 0
+        assert (out_root / "a" / "M1.lagda.md").exists()
+        assert (out_root / "b" / "c" / "M2.lagda.md").exists()
+
+    def test_collects_failures_without_aborting(
+        self, tmp_path: Path, fake_pandoc: Path
+    ):
+        in_root = tmp_path / "in"
+        out_root = tmp_path / "out"
+        in_root.mkdir()
+        (in_root / "good.lagda").write_text(
+            "\\begin{code}\nfoo = 1\n\\end{code}\n", encoding="utf-8"
+        )
+
+        # Simulate a per-file failure by making the output path's parent
+        # un-writable.  (Skip the test if running as root, where chmod
+        # has no effect.)
+        if os.geteuid() == 0:
+            pytest.skip("test relies on filesystem permissions; running as root")
+        out_root.mkdir(mode=0o555)
+        try:
+            succeeded, failed = convert_tree(
+                list(in_root.rglob("*.lagda")),
+                in_root=in_root,
+                out_root=out_root,
+                pandoc=str(fake_pandoc),
+            )
+            assert len(succeeded) == 0
+            assert len(failed) == 1
+            assert failed[0][0] == in_root / "good.lagda"
+        finally:
+            out_root.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# CLI — argument parsing and exit codes
+# ---------------------------------------------------------------------------
+class TestCLI:
+    def test_help_succeeds(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "convert_lagda" in out
+        assert "--in-tree" in out
+
+    def test_missing_args_returns_usage_error(self, capsys):
+        rc = main([])
+        assert rc == 1  # CLI usage error: returns 1 with a stderr message
+        err = capsys.readouterr().err
+        assert "INPUT is required" in err
+
+    def test_single_file_conversion(
+        self, tmp_path: Path, fake_pandoc: Path, capsys
+    ):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text("\\begin{code}\nfoo = 1\n\\end{code}\n", encoding="utf-8")
+
+        rc = main([
+            str(src), str(dst),
+            "--pandoc", str(fake_pandoc),
+        ])
+        assert rc == 0
+        assert dst.exists()
+        out = capsys.readouterr().out
+        assert "wrote" in out
+
+    def test_check_mode_succeeds_without_writing(
+        self, tmp_path: Path, fake_pandoc: Path, capsys
+    ):
+        src = tmp_path / "Foo.lagda"
+        src.write_text("\\begin{code}\nfoo = 1\n\\end{code}\n", encoding="utf-8")
+        # Output not provided; --check should still succeed.
+        rc = main([str(src), "--check", "--pandoc", str(fake_pandoc)])
+        assert rc == 0
+        assert "check passed" in capsys.readouterr().out
+
+    def test_in_tree_mode_with_no_lagda_files_errors(
+        self, tmp_path: Path, fake_pandoc: Path
+    ):
+        empty_in = tmp_path / "empty"
+        empty_in.mkdir()
+        rc = main([
+            "--in-tree", str(empty_in),
+            "--out-tree", str(tmp_path / "out"),
+            "--pandoc", str(fake_pandoc),
+        ])
+        assert rc == 1


### PR DESCRIPTION
Implements #4.  The package is now end-to-end runnable on a single .lagda file or a whole tree.

## What's new

+  `lagda_md/core.py` — `convert_file`, `convert_tree`, and `ConversionError`.  These are the runtime entry points: preprocess → Pandoc → postprocess, with per-stage error reporting.
+  `lagda_md/cli.py` — argparse-based dispatch for single-file, whole-tree, and `--check` modes.
+  `lagda_md/__main__.py` — enables `python3 -m lagda_md`.
+  `convert_lagda.py` at repo root — convenience wrapper with `#!/usr/bin/env python3` shebang for direct invocation.

## Test strategy

Tests use a fake Pandoc shell script that copies its input to its output, exercising the four-stage pipeline end-to-end without requiring Pandoc to be installed.  This lets the test suite stay fast and deterministic; an integration suite against real Pandoc is a sensible follow-up issue.

## Notes for review

+  **Cross-refs in single-file mode are intentionally restricted.**  Cross-references resolve against a label map built from a *tree* of .lagda files, not from one file in isolation.  Single-file conversion with `--enable-cross-refs` raises a `ValueError` with a hint to use `--in-tree`; the CLI also catches this and prints the hint.
+  **Tree mode does a two-pass conversion** when `--enable-cross-refs` is set: first pass preprocesses every file to collect the label map, second pass runs the full pipeline.  Without `--enable-cross-refs`, only the second pass runs.
+  **`build_label_map` from #3 carries the cross-tree state.**  The decision to make it public in #3 pays off here: `convert_tree` uses it directly with no additional plumbing.
+  **The `agda-algebras` corpus will use the simplest path.**  The grep run earlier confirmed agda-algebras's .lagda files use only `\begin{code}` / `\end{code}` (and one `\begin{align*}` in pure prose).  None of the opt-in flags will fire for that corpus; it's the minimum-machinery case.

## What this PR does not do

+  No README rewrite (separate, in #5).
+  No integration tests against real Pandoc (deferred).
+  No Pandoc installation guidance in the README (covered in #5).
+  No agda-algebras dry-run (in #6).

Closes #4.
