### PR TITLE
Implement --input-format markdown for Markdown-literate .lagda files

### DIFF
--- a/lagda_md/__init__.py
+++ b/lagda_md/__init__.py
@@ -42,6 +42,7 @@ from .macros import MacroEntry, MacroTable
 from .preprocess import preprocess
 from .postprocess import postprocess, build_label_map
 from .core import ConversionError, convert_file, convert_tree
+from .markdown_pipeline import convert_markdown
 
 __all__ = [
     "ConversionError",
@@ -49,6 +50,7 @@ __all__ = [
     "MacroTable",
     "build_label_map",
     "convert_file",
+    "convert_markdown",
     "convert_tree",
     "postprocess",
     "preprocess",

--- a/lagda_md/cli.py
+++ b/lagda_md/cli.py
@@ -76,6 +76,7 @@ def _run_single_mode(
         convert_file(
             args.input,
             args.output,
+            input_format=args.input_format,
             macros=macros,
             enable_cross_refs=args.enable_cross_refs,
             enable_theorem_envs=args.enable_theorem_envs,
@@ -124,6 +125,7 @@ def _run_tree_mode(
         inputs,
         in_root=in_root,
         out_root=out_root,
+        input_format=args.input_format,
         macros=macros,
         enable_cross_refs=args.enable_cross_refs,
         enable_theorem_envs=args.enable_theorem_envs,
@@ -155,6 +157,7 @@ def _run_check_mode(
             convert_file(
                 args.input,
                 scratch_output,
+                input_format=args.input_format,
                 macros=macros,
                 enable_cross_refs=False,
                 enable_theorem_envs=args.enable_theorem_envs,
@@ -216,6 +219,20 @@ def _build_parser() -> argparse.ArgumentParser:
         "--check",
         action="store_true",
         help="Run conversion without writing output; exit 0 on success.",
+    )
+
+    formats = parser.add_argument_group("input format")
+    formats.add_argument(
+        "--input-format",
+        choices=["latex", "markdown"],
+        default="latex",
+        metavar="FORMAT",
+        help=(
+            "Input file flavor.  'latex' (default) treats the .lagda "
+            "file as LaTeX-literate Agda and runs through Pandoc.  "
+            "'markdown' treats it as Markdown-literate Agda with "
+            "\\begin{code} fences and skips Pandoc."
+        ),
     )
 
     customization = parser.add_argument_group("customization")

--- a/lagda_md/core.py
+++ b/lagda_md/core.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from .macros import MacroTable
 from .postprocess import build_label_map, postprocess
 from .preprocess import preprocess
+from .markdown_pipeline import convert_markdown
 
 __all__ = ["ConversionError", "convert_file", "convert_tree"]
 
@@ -60,6 +61,7 @@ def convert_file(
     input_path: Path,
     output_path: Path,
     *,
+    input_format: str = "latex",
     macros: MacroTable | None = None,
     enable_cross_refs: bool = False,
     enable_theorem_envs: bool = False,
@@ -75,6 +77,11 @@ def convert_file(
         input_path: Path to the .lagda source.
         output_path: Path where the .lagda.md result is written.  Parent
             directories are created if they don't exist.
+        input_format: Either "latex" (default) or "markdown".  Determines
+            which pipeline to dispatch to.  "latex" runs the four-stage
+            Pandoc-based pipeline.  "markdown" skips Pandoc and treats
+            the prose as already-Markdown, only handling code-block
+            extraction / restoration and macro expansion.
         macros: Optional macro table.  Defaults to the package's default table.
         enable_cross_refs: If True, resolve \\Cref / \\cref using label_map.
         enable_theorem_envs: If True, restore theorem/lemma/claim placeholders.
@@ -90,10 +97,60 @@ def convert_file(
         ConversionError: If any stage of the pipeline fails.
         FileNotFoundError: If `input_path` doesn't exist.
         ValueError: If enable_cross_refs=True but label_map=None.
+            Also raised if input_format is "markdown" with any opt-in
+            flag set; opt-in flags are LaTeX-pipeline-specific and don't
+            apply to Markdown input.
     """
+    if input_format not in ("latex", "markdown"):
+        raise ValueError(
+            f"input_format must be 'latex' or 'markdown', got {input_format!r}"
+        )
+
+    if input_format == "markdown":
+        if enable_cross_refs or enable_theorem_envs or enable_figure_envs:
+            raise ValueError(
+                "opt-in transformations (--enable-cross-refs, "
+                "--enable-theorem-envs, --enable-figure-envs) apply only "
+                "to --input-format latex; Markdown-literate sources use "
+                "Markdown-native mechanisms for cross-references, "
+                "theorems, and figures"
+            )
+        return convert_markdown(input_path, output_path, macros=macros)
+
+    # Below: input_format == "latex" — the original pipeline, unchanged.
     if macros is None:
         macros = MacroTable.default()
 
+    return _convert_file_latex(
+        input_path,
+        output_path,
+        macros=macros,
+        enable_cross_refs=enable_cross_refs,
+        enable_theorem_envs=enable_theorem_envs,
+        enable_figure_envs=enable_figure_envs,
+        label_map=label_map,
+        extra_lua_filters=extra_lua_filters,
+        pandoc=pandoc,
+        keep_temp=keep_temp,
+    )
+
+
+def _convert_file_latex(
+    input_path: Path,
+    output_path: Path,
+    *,
+    macros: MacroTable,
+    enable_cross_refs: bool = False,
+    enable_theorem_envs: bool = False,
+    enable_figure_envs: bool = False,
+    label_map: Mapping[str, Mapping[str, str]] | None = None,
+    extra_lua_filters: Iterable[Path] = (),
+    pandoc: str = "pandoc",
+    keep_temp: bool = False,
+) -> None:
+    """The original four-stage pipeline.  Kept as a private helper called
+    only by convert_file when input_format='latex'.
+    """
     if not input_path.exists():
         raise FileNotFoundError(f"input file does not exist: {input_path}")
     if enable_cross_refs and label_map is None:
@@ -126,6 +183,7 @@ def convert_tree(
     *,
     in_root: Path,
     out_root: Path,
+    input_format: str = "latex",
     macros: MacroTable | None = None,
     enable_cross_refs: bool = False,
     enable_theorem_envs: bool = False,
@@ -148,6 +206,8 @@ def convert_tree(
             compute output paths and label map keys.
         out_root: The directory under which output paths are written.
             Mirrors the input tree.
+        input_format: Either "latex" or "markdown"; forwarded to
+            convert_file for each input.
         Other args: forwarded to `convert_file`.
 
     Returns:
@@ -161,7 +221,7 @@ def convert_tree(
 
     # First pass for cross-refs: preprocess every file, collect outputs.
     label_map: dict[str, dict[str, str]] = {}
-    if enable_cross_refs:
+    if enable_cross_refs and input_format == "latex":
         logger.info("first pass: building cross-reference label map")
         preprocessed: dict[Path, str] = {}
         for src in inputs:
@@ -190,6 +250,7 @@ def convert_tree(
             convert_file(
                 src,
                 dst,
+                input_format=input_format,
                 macros=macros,
                 enable_cross_refs=enable_cross_refs,
                 enable_theorem_envs=enable_theorem_envs,

--- a/lagda_md/markdown_pipeline.py
+++ b/lagda_md/markdown_pipeline.py
@@ -1,0 +1,90 @@
+"""
+Markdown-literate Agda conversion pipeline.
+
+Handles `.lagda` files that are authored as Markdown prose with
+`\\begin{code}...\\end{code}` fences for Agda code (rather than as LaTeX
+prose, which is what the four-stage Pandoc pipeline in `lagda_md.core`
+handles).
+
+This pipeline is structurally simpler than the LaTeX one because the
+prose doesn't need conversion — it's already in the target format.
+The work reduces to:
+
+    1. Extract `\\begin{code}...\\end{code}` blocks (reusing the
+       always-on machinery in `lagda_md.preprocess`).
+    2. Expand custom and generic Agda macros in the prose.
+    3. Restore code blocks as fenced ```` ```agda ```` blocks (reusing
+       the always-on machinery in `lagda_md.postprocess`).
+
+YAML front matter, Markdown headings, reference-style links, Jekyll
+directives, and other Markdown-native constructs survive unchanged.
+
+The opt-in flags from the LaTeX pipeline (cross-refs, theorem envs,
+figure envs) don't apply here: Markdown-literate authors use Markdown's
+native mechanisms (reference-style links, custom CSS classes, headings)
+for those constructs and don't need our placeholder protocol.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from .macros import MacroTable
+from .postprocess import postprocess
+from .preprocess import preprocess
+
+__all__ = ["convert_markdown"]
+
+
+def convert_markdown(
+    input_path: Path,
+    output_path: Path,
+    *,
+    macros: MacroTable | None = None,
+) -> None:
+    """Convert one Markdown-literate .lagda file to .lagda.md.
+
+    Args:
+        input_path: Path to the .lagda source.
+        output_path: Path where the .lagda.md result is written.
+            Parent directories are created if absent.
+        macros: Optional macro table.  Defaults to the package's
+            default table; pass an empty `MacroTable.empty()` to
+            disable all macro expansion.
+
+    Raises:
+        FileNotFoundError: If `input_path` doesn't exist.
+        OSError: If reading input or writing output fails.
+    """
+    if macros is None:
+        macros = MacroTable.default()
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"input file does not exist: {input_path}")
+
+    content = input_path.read_text(encoding="utf-8")
+
+    # Stage 1: Extract code blocks and expand macros.  Opt-in flags are
+    # all False — none of them are meaningful for Markdown-literate input.
+    intermediate, code_blocks = preprocess(
+        content,
+        macros=macros,
+        enable_cross_refs=False,
+        enable_theorem_envs=False,
+        enable_figure_envs=False,
+    )
+
+    # Stage 2: Restore code blocks (the only postprocess step that fires
+    # for Markdown-literate input; cross-ref / theorem / figure resolvers
+    # are all gated by their respective flags).
+    final = postprocess(
+        intermediate,
+        code_blocks,
+        enable_cross_refs=False,
+        enable_theorem_envs=False,
+        enable_figure_envs=False,
+    )
+
+    # Stage 3: Write output.
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(final, encoding="utf-8")

--- a/lagda_md/markdown_pipeline.py
+++ b/lagda_md/markdown_pipeline.py
@@ -49,8 +49,10 @@ def convert_markdown(
         output_path: Path where the .lagda.md result is written.
             Parent directories are created if absent.
         macros: Optional macro table.  Defaults to the package's
-            default table; pass an empty `MacroTable.empty()` to
-            disable all macro expansion.
+            default table.  Pass `MacroTable.empty()` to disable
+            *custom* macro expansion; the built-in preprocessor
+            transformations (`\\ab` shorthand, generic `\\Agda...`
+            class expansion, `~` normalization) always apply.
 
     Raises:
         FileNotFoundError: If `input_path` doesn't exist.
@@ -66,9 +68,12 @@ def convert_markdown(
 
     # Stage 1: Extract code blocks and expand macros.  Opt-in flags are
     # all False — none of them are meaningful for Markdown-literate input.
+    # Tilde normalization is also disabled: in Markdown-literate prose,
+    # ~ has its own meanings (strikethrough ~~text~~, YAML null `key: ~`).
     intermediate, code_blocks = preprocess(
         content,
         macros=macros,
+        normalize_tildes=False,
         enable_cross_refs=False,
         enable_theorem_envs=False,
         enable_figure_envs=False,

--- a/lagda_md/preprocess.py
+++ b/lagda_md/preprocess.py
@@ -53,6 +53,7 @@ def preprocess(
     content: str,
     macros: MacroTable | None = None,
     *,
+    normalize_tildes: bool = True,
     enable_cross_refs: bool = False,
     enable_theorem_envs: bool = False,
     enable_figure_envs: bool = False,
@@ -60,14 +61,22 @@ def preprocess(
     """Transform LaTeX-literate Agda content into Pandoc-ready text.
 
     Always-on transformations:
-      * Code-block extraction (\\begin{code}...\\end{code} → @@CODEBLOCK_ID_n@@).
+      * Code-block extraction (\\begin{code}...\\end{code} → @@CODEBLOCK_ID_n@@),
+        including the [hide] variant for code that is type-checked but not
+        rendered.
       * Hidden code blocks (\\begin{code}[hide]...).
       * \\ab{x} → \\AgdaBound{x} shorthand expansion.
-      * ~ (LaTeX non-breaking space) → ' '.
+      * ~ (LaTeX non-breaking space) → ' ', if normalize_tildes is True.
       * Generic \\Agda...{name} expansion to AgdaTerm placeholders, for the
         nine standard Agda CSS classes listed in _GENERIC_AGDA_CLASSES.
       * Custom macros from the supplied MacroTable, also rendered as
         AgdaTerm placeholders.
+
+    Args:
+        normalize_tildes: When True (the default), `~` is rewritten as a
+            space.  Set to False for Markdown-literate input where `~`
+            has its own meaning (strikethrough, YAML null, etc.).
+        ...
 
     Opt-in transformations (each gated by the corresponding flag and emitting
     placeholders that lagda_md.postprocess knows how to resolve):
@@ -112,8 +121,11 @@ def preprocess(
     )
 
     # --- Stage 2: Always-on text transformations (order matters) ----------
-    # ~ normalization runs first; it's purely orthogonal.
-    processed = processed.replace("~", " ")
+    # ~ normalization runs first; it's purely orthogonal but only
+    # appropriate for LaTeX-literate input.  Markdown-literate input
+    # has its own meaning for ~ (strikethrough, YAML null) and disables it.
+    if normalize_tildes:
+        processed = processed.replace("~", " ")
 
     # --- Stage 3: Project-supplied macros (highest precedence) ------------
     # User-supplied entries get to override built-in shorthands like \ab,

--- a/lagda_md/tests/test_markdown_pipeline.py
+++ b/lagda_md/tests/test_markdown_pipeline.py
@@ -1,0 +1,270 @@
+"""Tests for lagda_md.markdown_pipeline and the Markdown-literate
+input format end-to-end.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lagda_md.cli import main
+from lagda_md.core import convert_file
+from lagda_md.macros import MacroEntry, MacroTable
+from lagda_md.markdown_pipeline import convert_markdown
+
+
+# ---------------------------------------------------------------------------
+# Direct convert_markdown tests
+# ---------------------------------------------------------------------------
+class TestConvertMarkdown:
+    def test_minimal_markdown_literate_file(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "# A heading\n"
+            "\n"
+            "Some prose.\n"
+            "\n"
+            "\\begin{code}\n"
+            "data ⊤ : Set where tt : ⊤\n"
+            "\\end{code}\n"
+            "\n"
+            "More prose.\n",
+            encoding="utf-8",
+        )
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+
+        assert "# A heading" in result
+        assert "Some prose." in result
+        assert "More prose." in result
+        assert "```agda" in result
+        assert "data ⊤ : Set where tt : ⊤" in result
+        # Code-block placeholder should be gone:
+        assert "@@CODEBLOCK_ID_" not in result
+
+    def test_yaml_front_matter_preserved(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "---\n"
+            "layout: default\n"
+            'title: "My Module"\n'
+            "---\n"
+            "\n"
+            "Body content.\n",
+            encoding="utf-8",
+        )
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+        assert result.startswith("---\nlayout: default\n")
+        assert "Body content." in result
+
+    def test_hidden_code_blocks_wrapped_in_html_comments(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "Public prose.\n"
+            "\n"
+            "\\begin{code}[hide]\n"
+            "{-# OPTIONS --safe #-}\n"
+            "module Foo where\n"
+            "\\end{code}\n",
+            encoding="utf-8",
+        )
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+        assert "<!--" in result
+        assert "module Foo where" in result
+        assert "-->" in result
+
+    def test_creates_parent_directories(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "deep" / "nested" / "out" / "Foo.lagda.md"
+        src.write_text("# Hi\n\\begin{code}\nfoo = 1\n\\end{code}\n", encoding="utf-8")
+        convert_markdown(src, dst)
+        assert dst.exists()
+
+    def test_missing_input_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            convert_markdown(tmp_path / "nope.lagda", tmp_path / "out.lagda.md")
+
+    def test_custom_macros_applied_to_prose(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "Use \\af{Subalgebras} as a reference.\n", encoding="utf-8"
+        )
+        macros = MacroTable.from_dict(
+            {
+                "agda_terms": {
+                    "af": {"basename": "", "agda_class": "AgdaFunction"},
+                }
+            }
+        )
+        convert_markdown(src, dst, macros=macros)
+        result = dst.read_text(encoding="utf-8")
+        assert "Subalgebras" in result
+        # The custom-macro expansion produces a placeholder which Pandoc
+        # would normally consume; in the Markdown pipeline there is no
+        # Pandoc, so the AgdaTerm placeholder appears as raw text.  The
+        # downstream MkDocs / Jekyll site is expected to handle these.
+        assert "@@AgdaTerm@@basename=Subalgebras@@class=AgdaFunction@@" in result
+
+    def test_no_code_blocks_passthrough(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "# Just prose\n\nNo code in this file.\n", encoding="utf-8"
+        )
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+        assert "# Just prose" in result
+        assert "No code in this file." in result
+
+    def test_multiple_code_blocks_restored_in_order(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "First.\n\n"
+            "\\begin{code}\nA = 1\n\\end{code}\n\n"
+            "Second.\n\n"
+            "\\begin{code}\nB = 2\n\\end{code}\n\n"
+            "Third.\n",
+            encoding="utf-8",
+        )
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+        assert result.index("A = 1") < result.index("B = 2")
+        assert result.index("First.") < result.index("Second.")
+        assert result.index("Second.") < result.index("Third.")
+
+
+# ---------------------------------------------------------------------------
+# convert_file dispatch + opt-in-flag rejection
+# ---------------------------------------------------------------------------
+class TestConvertFileDispatch:
+    def test_markdown_format_dispatches_to_markdown_pipeline(self, tmp_path: Path):
+        # Without Pandoc installed, the LaTeX pipeline would fail at Pandoc
+        # invocation.  The Markdown pipeline doesn't invoke Pandoc, so this
+        # test passes purely on the dispatch correctness.
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text("# Hi\n\\begin{code}\nfoo = 1\n\\end{code}\n", encoding="utf-8")
+        convert_file(src, dst, input_format="markdown")
+        assert dst.exists()
+        assert "```agda" in dst.read_text(encoding="utf-8")
+
+    def test_invalid_input_format_raises(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="input_format must be"):
+            convert_file(
+                tmp_path / "x.lagda",
+                tmp_path / "x.lagda.md",
+                input_format="rst",
+            )
+
+    @pytest.mark.parametrize(
+        "flag",
+        ["enable_cross_refs", "enable_theorem_envs", "enable_figure_envs"],
+    )
+    def test_markdown_input_with_optin_flag_raises(self, tmp_path: Path, flag: str):
+        src = tmp_path / "Foo.lagda"
+        src.write_text("trivial\n", encoding="utf-8")
+        kwargs = {"input_format": "markdown", flag: True}
+        with pytest.raises(ValueError, match="opt-in"):
+            convert_file(
+                src,
+                tmp_path / "Foo.lagda.md",
+                **kwargs,
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+class TestCLIMarkdownMode:
+    def test_input_format_markdown_via_cli(self, tmp_path: Path, capsys):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "---\nlayout: default\n---\n\n"
+            "# Test\n\n"
+            "\\begin{code}\nfoo = 1\n\\end{code}\n",
+            encoding="utf-8",
+        )
+
+        rc = main([str(src), str(dst), "--input-format", "markdown"])
+        assert rc == 0
+        result = dst.read_text(encoding="utf-8")
+        assert "layout: default" in result
+        assert "```agda" in result
+
+    def test_input_format_default_is_latex(self, capsys):
+        # Verify the help output documents 'latex' as the default.
+        with pytest.raises(SystemExit):
+            main(["--help"])
+        out = capsys.readouterr().out
+        assert "--input-format" in out
+        assert "latex" in out
+
+
+# ---------------------------------------------------------------------------
+# agda-algebras corpus shape (the failing case from the smoke test)
+# ---------------------------------------------------------------------------
+class TestAgdaAlgebrasShape:
+    def test_general_operations_and_relations_shape_round_trips(
+        self, tmp_path: Path
+    ):
+        """Reproduces the smoke-test failure case from #11's discovery.
+
+        agda-algebras's docs/lagda/Demos/GeneralOperationsAndRelations.lagda
+        has YAML front matter, a Markdown heading, reference-style
+        Markdown links, a Jekyll include directive, and a single hidden
+        code block.  The LaTeX pipeline failed with a Pandoc parser error
+        ("unexpected ()").  The Markdown pipeline should handle it
+        cleanly.
+        """
+        src = tmp_path / "GeneralOperationsAndRelations.lagda"
+        dst = tmp_path / "GeneralOperationsAndRelations.lagda.md"
+        src.write_text(
+            "---\n"
+            "layout: default\n"
+            'title : "Demos.GeneralOperationsAndRelations module"\n'
+            'date : "2022-04-27"\n'
+            'author: "the agda-algebras development team"\n'
+            "---\n"
+            "\n"
+            '### <a id="general-operations-and-relations">'
+            "General Opereations and Relations</a>\n"
+            "\n"
+            "+  [Signatures][Overture.Signatures]\n"
+            "+  [Operations][Overture.Operations]\n"
+            "+  [Relations][Base.Relations]\n"
+            "   +  [Discrete Relations][Base.Relations.Discrete]\n"
+            "   +  [Continuous Relations][Base.Relations.Continuous]\n"
+            "+  [Containers][]\n"
+            "\n"
+            "\\begin{code}[hide]\n"
+            "{-# OPTIONS --cubical-compatible --exact-split --safe #-}\n"
+            "\n"
+            "module Demos.GeneralOperationsAndRelations where\n"
+            "\\end{code}\n"
+            "\n"
+            "{% include UALib.Links.md %}\n",
+            encoding="utf-8",
+        )
+
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+
+        # Front matter preserved.
+        assert "layout: default" in result
+        # Heading preserved.
+        assert "general-operations-and-relations" in result
+        # Reference-style link preserved (we shouldn't be touching it).
+        assert "[Signatures][Overture.Signatures]" in result
+        # Jekyll directive preserved.
+        assert "{% include UALib.Links.md %}" in result
+        # Hidden code block restored as commented Agda block.
+        assert "<!--" in result
+        assert "module Demos.GeneralOperationsAndRelations where" in result

--- a/lagda_md/tests/test_markdown_pipeline.py
+++ b/lagda_md/tests/test_markdown_pipeline.py
@@ -268,3 +268,28 @@ class TestAgdaAlgebrasShape:
         # Hidden code block restored as commented Agda block.
         assert "<!--" in result
         assert "module Demos.GeneralOperationsAndRelations where" in result
+
+class TestTildePreservation:
+    def test_yaml_null_with_tilde_preserved(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "---\n"
+            "layout: default\n"
+            "subtitle: ~\n"
+            "---\n"
+            "\n"
+            "Body.\n",
+            encoding="utf-8",
+        )
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+        assert "subtitle: ~" in result
+
+    def test_markdown_strikethrough_preserved(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text("This is ~~deprecated~~ text.\n", encoding="utf-8")
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+        assert "~~deprecated~~" in result

--- a/lagda_md/tests/test_preprocess.py
+++ b/lagda_md/tests/test_preprocess.py
@@ -226,6 +226,14 @@ class TestFigureEnvsFlag:
         text, _blocks = preprocess(content, enable_figure_envs=True)
         assert "@@UNLABELLED_FIGURE_CAPTION@@" in text
 
+class TestNonBreakingSpaceFlag:
+    def test_normalize_tildes_default_is_true(self):
+        text, _blocks = preprocess("a~b")
+        assert text == "a b"
+
+    def test_normalize_tildes_false_preserves(self):
+        text, _blocks = preprocess("a~b", normalize_tildes=False)
+        assert text == "a~b"
 
 # ---------------------------------------------------------------------------
 # agda-algebras smoke test


### PR DESCRIPTION
Implements #11.  Adds a parallel pipeline for Markdown-literate `.lagda` input, addressing the corpus shape used by agda-algebras (the planned second-corpus validation in #6).

## Background

The smoke test against agda-algebras revealed that not all `.lagda` files share the FLS-style LaTeX-literate convention.  agda-algebras (and 1Lab, and other modern Agda projects) author their `.lagda` files as Markdown prose with `\begin{code}` fences.  Pandoc cannot read these as LaTeX; it sees Markdown syntax and bails.

## What this adds

A new `lagda_md.markdown_pipeline` module exposing `convert_markdown(input_path, output_path, *, macros)`.  The pipeline:

+  Extracts `\begin{code}...\end{code}` blocks (reusing `lagda_md.preprocess`'s always-on machinery).
+  Applies custom and generic Agda macro expansion to the prose.
+  Restores code blocks as fenced ``` ```agda ``` blocks (visible) or HTML-commented blocks (hidden).
+  Writes the output.  YAML front matter, Markdown headings, reference links, and Jekyll directives survive unchanged.

The CLI gains an `--input-format` flag (`latex` default, `markdown` opt-in).  `convert_file` becomes a dispatcher; the previous LaTeX pipeline body is preserved as `_convert_file_latex`, called only when `input_format='latex'`.

## What this doesn't add

+  Auto-detection.  The user specifies; if the wrong format is chosen, the failure is loud (Pandoc parser error in the LaTeX case, unexpanded macros in the Markdown case).  Heuristic detection can be added later.
+  Format conversion.  This issue is about *consuming* Markdown-literate input, not transforming LaTeX-literate to Markdown-literate or vice versa.

## Notes for review

+  **Macro-expansion-without-Pandoc has a small wart.**  Custom macros expand to `@@AgdaTerm@@basename=...@@class=...@@` placeholder text, which the LaTeX pipeline would normally feed to Pandoc and the Lua filter would consume.  In the Markdown pipeline there is no Pandoc, so these placeholders survive into the output.  Downstream rendering (MkDocs, Jekyll, etc.) is expected to handle them — typically through a CSS class or a custom Markdown extension.  Documented in `convert_markdown`'s docstring, tested by `test_custom_macros_applied_to_prose`.  If a future user wants HTML-rendered macros directly, that's a follow-up issue.
+  **Opt-in flags are explicitly rejected** for `--input-format markdown` rather than silently ignored, matching the precedent set in #10's review where `--check + --in-tree` was likewise rejected.

## Validation

+  All 80 existing tests pass.
+  16 new tests pass.
+  The agda-algebras smoke-test failure case is now a regression test (`TestAgdaAlgebrasShape::test_general_operations_and_relations_shape_round_trips`).

Closes #11.
Unblocks #5 (README rewrite) and #6 (agda-algebras end-to-end validation).
