### PR TITLE
markdown pipeline: emit kramdown attribute spans, rewrite \href

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ Some transformations apply unconditionally; others are gated by opt-in flags.
 +   `\ab{x}` shorthand expansion to `\AgdaBound{x}`.
 +   Custom macros from the supplied `--macros` table.
 
+The Markdown pipeline (`--input-format markdown`) additionally:
+
++   Resolves all custom-macro and `\Agda...` invocations to **kramdown attribute spans** of the form `` `name`{.AgdaClass} ``.  Jekyll's default kramdown processor and most other modern Markdown engines style these via CSS class.  Pair with a `custom.css` providing per-class rules; see the formal-ledger-specifications project for the canonical reference.
++   Rewrites LaTeX `\href{url}{text}` as Markdown `[text](url)`.
+
 **Opt-in transformations** apply only to LaTeX-literate input and only when their flags are passed:
 
 +   `--enable-cross-refs` — Resolves `\label{...}`, `\Cref{...}`, `\cref{...}` against a label map computed from the whole input tree. Loads `lagda_md/filters/cross-refs.lua` as an additional Pandoc filter.

--- a/docs/corpora/agda-algebras.md
+++ b/docs/corpora/agda-algebras.md
@@ -1,0 +1,90 @@
+<!-- File: docs/corpora/agda-algebras.md -->
+
+# Corpus validation: agda-algebras
+
+This document records the end-to-end validation of `lagda_md`'s Markdown-literate input pipeline against the [agda-algebras](https://github.com/ualib/agda-algebras) corpus, performed for migrator issue [#6](https://github.com/williamdemeo/agda-lagda-migrator/issues/6).  It is the second external-corpus validation of the package, after the formal-ledger-specifications corpus that originally seeded the LaTeX pipeline at `examples/fls-pipeline/`.
+
+##  Corpus snapshot
+
++  Repository: https://github.com/ualib/agda-algebras
++  Branch: `280-m1-8-apply-agda-lagda-migrator`
++  Source layout at validation time: 127 `.lagda` files under `docs/lagda/`, authored as Markdown prose with `\begin{code}…\end{code}` Agda fences (the agda-algebras and 1Lab convention).
++  Toolchain: Agda 2.8.0, stdlib 2.3, `--cubical-compatible --safe`.
+
+The audit script `scripts/audit_lagda_migration.sh` in the agda-algebras repo classified the corpus as 127 `.lagda` files paired with 127 `.agda` companions under `src/`, of which 3 were skeletons (pragma + module-header only) and 124 were "substantive" by line-count heuristic.  All 124 substantive `.agda` companions were derived mechanically by the project's `admin/illiterator/` Haskell program from their `.lagda` partners, so the `.lagda` files were the single source of truth for both prose and code.
+
+##  Macros encountered
+
+A grep of the corpus body revealed five custom macros beyond `lagda_md`'s always-on baselines (the nine generic `\Agda…{name}` classes plus the `\ab{x}` shorthand):
+
+| Macro    | Frequency | Mapped to                       |
+|----------|----------:|---------------------------------|
+| `\ab{}`  | 6         | `AgdaBound` (also default-table)|
+| `\af{}`  | 3         | `AgdaFunction`                  |
+| `\au{}`  | 2         | `AgdaArgument`                  |
+| `\as{}`  | 1         | `AgdaSymbol`                    |
+| `\ar{}`  | 1         | `AgdaRecord`                    |
+
+Counts derived by:
+
+```sh
+grep -rEho '\\[a-zA-Z]+\{' --include='*.lagda' docs/lagda/ | sort | uniq -c | sort -rn
+```
+
+The corresponding macro table lives in agda-algebras at `admin/agda-algebras-macros.json` and was passed via `--macros` on the conversion command.
+
+##  Conversion command
+
+```sh
+python3 /path/to/agda-lagda-migrator/convert_lagda.py \
+    --input-format markdown \
+    --macros admin/agda-algebras-macros.json \
+    --in-tree docs/lagda/ \
+    --out-tree _scratch/converted/
+```
+
+Output: `converted 127 of 127 files`.
+
+##  Validation method
+
+The acceptance test for the migrator's correctness on this corpus is end-to-end Agda type-checking of the migrated tree.  After the converted files were placed at their canonical `src/X/Y/Z.lagda.md` paths and the now-redundant `.agda` companions deleted, the corpus's existing `make check` target was run.  This builds `src/Everything.agda` from a `find … *.lagda.md … *.agda` enumeration and invokes Agda on it.
+
+##  Result
+
+`make check` passes.
+
+Excerpt of `make check` output:
+
+```
+target: Everything.agda
+  wrote src/Everything.agda (127 modules)
+target: check
+agda +RTS -M6G -A128M -RTS  src/Everything.agda
+Checking Everything (…/src/Everything.agda).
+ Checking Base (…/src/Base.lagda.md).
+…
+ Checking agda-algebras (…/src/agda-algebras.lagda.md).
+```
+
+All 127 modules of the migrated tree type-check cleanly under the project's `--cubical-compatible --safe` flag set.
+
+##  Findings
+
+###  Migrator behavior was correct
+
+The migrator's Markdown pipeline produced faithful conversions in every case.  The five custom-macro shorthands resolved correctly to kramdown attribute spans of the form `` `name`{.AgdaClass} ``, and code blocks were preserved verbatim under `` ```agda `` fences.  YAML front matter, Markdown headings, reference-style links, and Jekyll directives like `{% include UALib.Links.md %}` were passed through unchanged.
+
+###  Two adjustments required, both narrowly scoped
+
++  **Corpus-side: `\begin{code}` used for non-type-checked illustrative snippets.**  In a small number of files the corpus author had used `\begin{code}…\end{code}` to wrap explanatory code intended for visual presentation only, with no expectation of compilation.  Under the literate-LaTeX pipeline this worked because `agda --latex` highlights such blocks but the rendered HTML's `make html` was the only consumer; under the new `.lagda.md` shape, every `` ```agda `` fence is consumed by the type-checker.  The corpus maintainer addressed this case-by-case by removing the fences and re-indenting as four-space code blocks, which Markdown renders as monospace without invoking Agda.  The migrator did the right thing — it converted every code fence faithfully — and no migrator change is indicated.
++  **Migrator-side: blank-line padding around code fences.**  The corpus convention was to leave a blank line after `\begin{code}` and before `\end{code}`; the migrator preserves these, producing converted files with an extra blank line between the opening `` ```agda `` fence and the first line of code.  This is cosmetic and does not affect type-checking or rendering correctness, but produces visually noisy output.  Tracked as enhancement [#15](https://github.com/williamdemeo/agda-lagda-migrator/issues/15); a future `--trim-fence-padding` flag would address it.
+
+##  Conclusion
+
+The Markdown-literate pipeline is validated for the agda-algebras shape of corpus.  Of 127 files converted, 127 type-check, with the residual issues identified narrowly scoped (one corpus-side authoring convention; one migrator-side cosmetic enhancement).  The pipeline is fit for production use on similar Markdown-literate Agda corpora.
+
+##  Reproduction
+
+The full migration including the validation step lives on the agda-algebras branch [`280-m1-8-apply-agda-lagda-migrator`](https://github.com/ualib/agda-algebras/tree/280-m1-8-apply-agda-lagda-migrator).  See ualib/agda-algebras#280 for context, [ADR-004](https://github.com/ualib/agda-algebras/blob/master/docs/adr/004-lagda-md-canonical.md) for the design rationale, and the corresponding migrator PR for the kramdown-attribute-span change that landed alongside this validation.
+
+

--- a/lagda_md/markdown_pipeline.py
+++ b/lagda_md/markdown_pipeline.py
@@ -26,6 +26,7 @@ for those constructs and don't need our placeholder protocol.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Iterable
 
@@ -34,6 +35,60 @@ from .postprocess import postprocess
 from .preprocess import preprocess
 
 __all__ = ["convert_markdown"]
+
+
+# Match LaTeX \href{url}{text} in prose.  Code blocks have already been
+# extracted to placeholders by preprocess() before this regex runs, so
+# any \href that survives is genuinely in prose.  The pattern assumes
+# neither {url} nor {text} contains a literal { or } — robust enough for
+# the corpora we target (FLS, agda-algebras, 1Lab).
+_HREF_PATTERN = re.compile(r"\\href\{([^}]*)\}\{([^}]*)\}")
+
+
+# Match the AgdaTerm placeholder that preprocess() emits for both the
+# always-on generic \Agda... family and any custom-macro entries.  In
+# the LaTeX pipeline these are consumed by the agda-filter.lua Pandoc
+# filter; in the Markdown pipeline there is no Pandoc, so we resolve
+# them here.
+_AGDA_TERM_PLACEHOLDER_PATTERN = re.compile(
+    r"\\texttt\{@@AgdaTerm@@basename=(.*?)@@class=(\w+)@@\}"
+)
+
+
+def _rewrite_href_to_markdown(content: str) -> str:
+    """Rewrite LaTeX `\\href{url}{text}` in prose as Markdown `[text](url)`.
+
+    Markdown-literate `.lagda` files in the wild often interleave LaTeX
+    `\\href` calls with otherwise-Markdown prose; without this rewrite
+    they would survive verbatim into the converted output.
+    """
+    return _HREF_PATTERN.sub(
+        lambda m: f"[{m.group(2)}]({m.group(1)})",
+        content,
+    )
+
+
+def _resolve_agda_term_placeholders(content: str) -> str:
+    """Convert AgdaTerm placeholders to kramdown attribute spans.
+
+    `\\af{Foo}` (a custom-macro invocation) or `\\AgdaFunction{Foo}` (a
+    direct generic invocation) becomes `` `Foo`{.AgdaFunction} `` — the
+    inline-code-with-attribute-class syntax that kramdown (Jekyll's
+    default Markdown processor) and Pandoc both recognize.  Pair with
+    a `custom.css` providing per-class colors; see the formal-ledger-
+    specifications project for the canonical reference.
+    """
+    def _unescape(s: str) -> str:
+        # Reverse the @@ → @ @ escape that preprocess() applies to
+        # placeholder payloads, so literal @@ in user content survives.
+        return s.replace("@ @", "@@")
+
+    def _replace(match: re.Match) -> str:
+        basename = _unescape(match.group(1))
+        agda_class = match.group(2)
+        return f"`{basename}`{{.{agda_class}}}"
+
+    return _AGDA_TERM_PLACEHOLDER_PATTERN.sub(_replace, content)
 
 
 def convert_markdown(
@@ -79,7 +134,14 @@ def convert_markdown(
         enable_figure_envs=False,
     )
 
-    # Stage 2: Restore code blocks (the only postprocess step that fires
+    # Stage 2: Resolve placeholders and rewrite LaTeX-prose-isms that
+    # have native Markdown equivalents.  This must happen BEFORE
+    # postprocess() restores code blocks: the rewrites apply to prose
+    # only, and code blocks are still placeholdered at this point.
+    intermediate = _rewrite_href_to_markdown(intermediate)
+    intermediate = _resolve_agda_term_placeholders(intermediate)
+
+    # Stage 3: Restore code blocks (the only postprocess step that fires
     # for Markdown-literate input; cross-ref / theorem / figure resolvers
     # are all gated by their respective flags).
     final = postprocess(
@@ -90,6 +152,6 @@ def convert_markdown(
         enable_figure_envs=False,
     )
 
-    # Stage 3: Write output.
+    # Stage 4: Write output.
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(final, encoding="utf-8")

--- a/lagda_md/tests/test_markdown_pipeline.py
+++ b/lagda_md/tests/test_markdown_pipeline.py
@@ -104,12 +104,36 @@ class TestConvertMarkdown:
         )
         convert_markdown(src, dst, macros=macros)
         result = dst.read_text(encoding="utf-8")
-        assert "Subalgebras" in result
-        # The custom-macro expansion produces a placeholder which Pandoc
-        # would normally consume; in the Markdown pipeline there is no
-        # Pandoc, so the AgdaTerm placeholder appears as raw text.  The
-        # downstream MkDocs / Jekyll site is expected to handle these.
-        assert "@@AgdaTerm@@basename=Subalgebras@@class=AgdaFunction@@" in result
+        # AgdaTerm placeholders are resolved to kramdown attribute spans
+        # — the format Jekyll's kramdown processor styles via CSS class.
+        # Pair with a custom.css providing the per-class rules.
+        assert "`Subalgebras`{.AgdaFunction}" in result
+        # No placeholder string survives the resolution step.
+        assert "@@AgdaTerm@@" not in result
+
+    def test_href_rewritten_to_markdown_link(self, tmp_path: Path):
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text(
+            "See the \\href{https://example.com}{example site} for more.\n",
+            encoding="utf-8",
+        )
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+        assert "[example site](https://example.com)" in result
+        assert "\\href" not in result
+
+    def test_ab_shorthand_renders_as_kramdown_span(self, tmp_path: Path):
+        # \ab{x} → \AgdaBound{x} via the always-on shorthand fallback,
+        # then the generic \Agda... → AgdaTerm placeholder, then this
+        # PR's resolution to a kramdown span.
+        src = tmp_path / "Foo.lagda"
+        dst = tmp_path / "Foo.lagda.md"
+        src.write_text("Let \\ab{x} be a binding.\n", encoding="utf-8")
+        convert_markdown(src, dst)
+        result = dst.read_text(encoding="utf-8")
+        assert "`x`{.AgdaBound}" in result
+        assert "@@AgdaTerm@@" not in result
 
     def test_no_code_blocks_passthrough(self, tmp_path: Path):
         src = tmp_path / "Foo.lagda"


### PR DESCRIPTION
Closes #6.

##  Motivation

The Markdown-literate pipeline previously emitted raw AgdaTerm placeholders (`\texttt{@@AgdaTerm@@basename=N@@class=C@@}`) into `.lagda.md` output, predicated on a downstream Lua filter that the LaTeX pipeline supplies via Pandoc but the Markdown pipeline does not.  In practice the placeholders survived into rendered HTML as literal text in projects (1Lab, agda-algebras) that consume the migrator's output through Jekyll/MkDocs without a Lua filter in the path.

##  What changes

+  **Kramdown attribute spans replace placeholders.**  `\af{Foo}` (a custom-macro invocation) or `\AgdaFunction{Foo}` (a direct generic invocation) now becomes `` `Foo`{.AgdaFunction} `` in the converted prose.  Kramdown — Jekyll's default Markdown processor — and Pandoc both recognize this inline-code-with-attribute-class form and let downstream CSS provide per-class styling.  The convention follows the formal-ledger-specifications project, where it pairs with a `custom.css` supplying per-class colors for both light and dark themes.
+  **`\href{url}{text}` is rewritten to Markdown `[text](url)`.**  An always-on Markdown-pipeline transform.  Some Markdown-literate `.lagda` files in the wild use the LaTeX form despite Markdown's native link syntax being available; without this rewrite they would survive verbatim into the converted output.

Both rewrites are Markdown-pipeline-specific; the LaTeX pipeline's behavior is unchanged.

##  Tests

+  `test_custom_macros_applied_to_prose` updated to assert the kramdown form (it previously asserted the raw placeholder).
+  `test_href_rewritten_to_markdown_link` added.
+  `test_ab_shorthand_renders_as_kramdown_span` added — exercises the chain from `\ab{x}` through the always-on shorthand fallback to the kramdown output.

##  Validation

The Markdown pipeline was end-to-end validated against the [agda-algebras](https://github.com/ualib/agda-algebras) corpus (127 files), which is now its second-corpus check after the formal-ledger-specifications corpus that originally seeded the package.  The full validation report is at `docs/corpora/agda-algebras.md` (added in a follow-up commit on this branch before this PR is marked ready for review).  Headline result: `make check` passes end-to-end against all 127 modules of the migrated agda-algebras tree on Agda 2.8.0 with stdlib 2.3 under `--cubical-compatible --safe`.

##  Documentation

`README.md`'s "Available transformations" section grows a paragraph describing the two new Markdown-pipeline behaviors and pointing at the formal-ledger-specifications custom-CSS reference.

##  Follow-up

One known cosmetic issue surfaced during validation that this PR does not address: the converter preserves blank lines that authors put immediately after `\begin{code}` and before `\end{code}`, which in the converted `.lagda.md` shows up as a blank line between the opening `` ```agda `` fence and the first line of code.  Filed as a separate enhancement on this repo: see #15.